### PR TITLE
[FE] Dashboard 페이지용 수입/지출 내역 추가 및 반응형 css 추가

### DIFF
--- a/client/src/components/containers/DashboardContainer.jsx
+++ b/client/src/components/containers/DashboardContainer.jsx
@@ -1,7 +1,22 @@
 import { useSelector } from 'react-redux';
+import styled from 'styled-components';
 
 import DashboardVisualExpense from '../presentational/DashboardVisualExpense';
-import DashboardTextExpense from '../presentational/DashboardTextExpese';
+import DashboardTextExpense from '../presentational/DashboardTextExpense';
+
+const StyledDiv = styled.div`
+  display: flex;
+  & > * {
+    margin-right: 1rem;
+  }
+`;
+
+const MediaTextExpense = styled.div`
+  transition: 1s;
+  @media (max-width: 967px) {
+    transform: translate(-160%, 110%);
+  }
+`;
 
 const DashboardContainer = () => {
   const transactions = useSelector((state) => state.transactions);
@@ -18,8 +33,12 @@ const DashboardContainer = () => {
   return (
     <>
       <div>DashboardContainer</div>
-      <DashboardVisualExpense transactions={transactions} />
-      <DashboardTextExpense transactions={transactionByCard} />
+      <StyledDiv>
+        <DashboardVisualExpense transactions={transactions} />
+        <MediaTextExpense>
+          <DashboardTextExpense transactions={transactionByCard} />
+        </MediaTextExpense>
+      </StyledDiv>
     </>
   );
 };

--- a/client/src/components/containers/DashboardContainer.jsx
+++ b/client/src/components/containers/DashboardContainer.jsx
@@ -1,14 +1,25 @@
-import DashboardVisualExpense from '../presentational/DashboardVisualExpense';
-
 import { useSelector } from 'react-redux';
+
+import DashboardVisualExpense from '../presentational/DashboardVisualExpense';
+import DashboardTextExpense from '../presentational/DashboardTextExpese';
 
 const DashboardContainer = () => {
   const transactions = useSelector((state) => state.transactions);
+
+  const transactionByCard = transactions.reduce((acc, cur) => {
+    const index = acc.findIndex((item) => item.card === cur.card);
+    if (acc[index]) {
+      acc[index].cost += cur.cost;
+      return acc;
+    }
+    return [...acc, { card: cur.card, cost: cur.cost }];
+  }, []);
 
   return (
     <>
       <div>DashboardContainer</div>
       <DashboardVisualExpense transactions={transactions} />
+      <DashboardTextExpense transactions={transactionByCard} />
     </>
   );
 };

--- a/client/src/components/presentational/DashboardTextExpense.jsx
+++ b/client/src/components/presentational/DashboardTextExpense.jsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import styled, { css } from 'styled-components';
+
+const StyledDiv = styled.div`
+  border: 1px solid #ddd;
+  width: fit-content;
+  padding: 12px;
+`;
+//TODO: 그래프 css 수정 후 이 css도 다 다시 수정
+const Title = styled.div``;
+
+const Body = styled.div``;
+
+const Tabs = styled.div`
+  display: flex;
+`;
+
+const Tab = styled.div`
+  padding: 0.5rem 3rem;
+  font-size: 12px;
+  white-space: nowrap;
+  &:hover {
+    cursor: pointer;
+  }
+
+  ${(props) => {
+    if (props.isActive) {
+      return css`
+        border-bottom: 2px solid black;
+        color: black;
+      `;
+    }
+    return css`
+      border-bottom: 1.5px solid #ebe7e7;
+      color: grey;
+    `;
+  }}
+`;
+
+const SmallText = styled.span`
+  font-size: 10px;
+  color: grey;
+`;
+
+const Info = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0.7rem 0px;
+  & > * {
+    margin-left: auto;
+  }
+`;
+
+const Underline = styled.div`
+  border-bottom: 1.5px solid #ebe7e7;
+  width: 80%;
+  margin-left: auto;
+  margin-bottom: 0.5rem;
+`;
+
+const DashboardTextExpense = ({ transactions }) => {
+  const [expenseStatus, setExpenseStatus] = useState(true);
+  const [profitStatus, setProfitStatus] = useState(false);
+  let total = 0;
+  let expenseTotal = 0;
+  let profitTotal = 0;
+
+  const handleOnClick = (e) => {
+    if (e.target.innerText === '지출') {
+      setExpenseStatus(true);
+      setProfitStatus(false);
+      return;
+    }
+    setExpenseStatus(false);
+    setProfitStatus(true);
+  };
+
+  const cardTransactions = transactions.map((transaction, i) => {
+    total += transaction.cost;
+    if (transaction.cost > 0) {
+      expenseTotal += transaction.cost;
+    }
+    if (transaction.cost < 0) {
+      profitTotal += transaction.cost;
+    }
+    // TODO/고민:
+    // 이걸 여기서 연산해도 되는지?
+    // profit이 양수? expense가 음수??
+    // 나중에 지출/수입 형태 결정되면 다시 수정하기
+    return (
+      <Info key={`card-transaction${i}`}>
+        <SmallText>{transaction.card}</SmallText>
+        <span>{Number(transaction.cost).toLocaleString()}</span>
+      </Info>
+    );
+  });
+
+  return (
+    <>
+      <StyledDiv>
+        <Title>결제 방식별 지출</Title>
+        <Tabs>
+          <Tab isActive={expenseStatus} onClick={handleOnClick}>
+            <span>지출</span>
+          </Tab>
+          <Tab isActive={profitStatus} onClick={handleOnClick}>
+            수입
+          </Tab>
+        </Tabs>
+        <Body>
+          <Info>
+            <SmallText>전체</SmallText>
+            <span>
+              {expenseStatus && Number(total).toLocaleString()}
+              {profitStatus && '-' + Number(total).toLocaleString()}
+            </span>
+          </Info>
+          <Underline />
+          {expenseStatus && cardTransactions}
+          {profitStatus && (
+            <Info>
+              <SmallText>수입</SmallText>
+              <span>{profitTotal.toLocaleString()}</span>
+              <SmallText>지출</SmallText>
+              <span>-{expenseTotal.toLocaleString()}</span>
+            </Info>
+          )}
+        </Body>
+      </StyledDiv>
+    </>
+  );
+};
+
+export default DashboardTextExpense;


### PR DESCRIPTION
## ✅ 작업 내용
- [x] Dashboard 페이지용 수입/지출 내역 추가
  - 반응형으로 크기에 따라 위치 변경

## 🔨 변경 사항 (구현 사항)
- [x] 대시 보드 페이지에 수입/지출 내역 추가

## 📸 스크린샷 (Optional)
968px 이상/ 967px 이하
![대시보드결제방식별지출반응형](https://user-images.githubusercontent.com/57941049/100601289-be18fa00-3345-11eb-97f9-269a7b10bec0.png)

## 🔒 관련이슈 (Optional)
- close #33
