### PR TITLE
 category/tag 페이지 UI 구현

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
   rules: {
     'react/react-in-jsx-scope': 'off',
     indent: ['error', 2],
+    'react/prop-types': 0,
   },
 };

--- a/client/public/color.js
+++ b/client/public/color.js
@@ -1,13 +1,17 @@
 const color = {
   line: '#EEEEEE',
+  lineBold: '#DDDDDD',
   fontNormal: '#777777',
   fontBold: '#222222',
+  fontDescription: '#757575',
   fontLightBold: '#616161',
   pageBackground: '#FDFDFE',
   boxShadow: '1px 1px 5px 0px #e7e7e7',
   backgroundColor: '#fff',
   hoverColor: '#f5f5f5',
   modal: '#666666',
+  dropDownHoverText: '#353535',
+  dropDownHoverBackground: '#fafafa',
 };
 
 export default color;

--- a/client/public/icon.js
+++ b/client/public/icon.js
@@ -1,0 +1,22 @@
+import * as GrIcons from 'react-icons/gr';
+import * as IoIcons from 'react-icons/io';
+import * as BiIcons from 'react-icons/bi';
+import * as HiIcons from 'react-icons/hi';
+import * as FaIcons from 'react-icons/fa';
+import * as GiIcons from 'react-icons/gi';
+import * as MdIcons from 'react-icons/md';
+
+const icon = {
+  meal: <GiIcons.GiMeal size={15} />,
+  cafe: <IoIcons.IoMdCafe size={15} />,
+  drink: <BiIcons.BiDrink size={15} />,
+  living: <HiIcons.HiShoppingCart size={15} />,
+  onlineShopping: <BiIcons.BiMouseAlt size={15} />,
+  shopping: <FaIcons.FaShoppingBag size={15} />,
+  finance: <GrIcons.GrMoney size={15} />,
+  medical: <FaIcons.FaBriefcaseMedical size={15} />,
+  more: <MdIcons.MdMoreVert size={20} />,
+  tagDefault: <MdIcons.MdLocalOffer size={15} />,
+};
+
+export default icon;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,7 +5,7 @@ import LoginPage from './pages/LoginPage';
 import AccountBookPage from './pages/AccountBookPage';
 import AnalysisPage from './pages/AnalysisPage';
 import CalendarPage from './pages/CalendarPage';
-import CategoryPage from './pages/CategoryPage';
+import CategoryTagPage from './pages/CategoryTagPage';
 import DashboardPage from './pages/DashboardPage';
 import NotFoundPage from './pages/NotFoundPage';
 import PaymentMethodPage from './pages/PaymentMethodPage';
@@ -32,7 +32,7 @@ const App = () => {
           <Route path="/account-book" component={AccountBookPage} />
           <Route path="/analysis" component={AnalysisPage} />
           <Route exact path="/calendar" component={CalendarPage} />
-          <Route path="/category" component={CategoryPage} />
+          <Route path="/category" component={CategoryTagPage} />
           <Route path="/dashboard" component={DashboardPage} />
           <Route path="/payment-method" component={PaymentMethodPage} />
           <Route path="/setting" component={SettingPage} />

--- a/client/src/components/presentational/category_tag/Card.jsx
+++ b/client/src/components/presentational/category_tag/Card.jsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+import icon from '@public/icon';
+import color from '@public/color';
+import DropDown from '../common/DropDown';
+
+const CardWrapper = styled.div`
+  flex: 1 0 45%;
+  box-sizing: border-box;
+  border: 1px solid ${color.lineBold};
+  margin: 10px;
+  padding: 10px;
+  min-width: 400px;
+  .card-header {
+    display: flex;
+    position: relative;
+  }
+  .card-title {
+    font-weight: bold;
+    font-size: 0.9rem;
+    margin-left: 0.4rem;
+  }
+  .card-description {
+    margin-top: 20px;
+    font-size: 0.8rem;
+    color: ${color.fontDescription};
+  }
+  .drop-down-btn {
+    width: 24px;
+    height: 24px;
+    line-height: 20px;
+    text-align: center;
+    position: absolute;
+    right: 0px;
+    transition: 0.3s;
+    svg {
+      fill: #808080;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      left: 0;
+      right: 0;
+      margin: auto;
+      text-align: center;
+    }
+    &:hover {
+      svg {
+        fill: #ffffff;
+      }
+      background-color: #8d45ff;
+      border-radius: 50%;
+    }
+  }
+
+  @media (max-width: 767px) {
+    flex: 1 0 100%;
+  }
+`;
+
+const IconWrapper = styled.div`
+  position: relative;
+  width: 22px;
+  height: 22px;
+  background-color: orange;
+  border-radius: 50%;
+
+  svg {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 0;
+    right: 0;
+    margin: auto;
+    text-align: center;
+    fill: white;
+  }
+`;
+
+const Card = ({ iconName, title, description }) => {
+  const [dropdown, setDropDown] = useState(false);
+  const dropDownOptions = ['분석에서 제외', '보고서 보기', '내역 보기'];
+  return (
+    <>
+      <CardWrapper>
+        <div className="card-header">
+          <IconWrapper>{icon[iconName]}</IconWrapper>
+          <div className="card-title">{title}</div>
+          <div className="drop-down-btn" onClick={() => setDropDown(!dropdown)}>
+            {icon.more}
+          </div>
+          {dropdown && (
+            <DropDown options={dropDownOptions} setDropDown={setDropDown} />
+          )}
+        </div>
+        <div className="card-description">{description}</div>
+      </CardWrapper>
+    </>
+  );
+};
+
+export default Card;

--- a/client/src/components/presentational/category_tag/CardContainer.jsx
+++ b/client/src/components/presentational/category_tag/CardContainer.jsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+import Card from './Card';
+
+const CardContainerWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const CardContainer = ({ dummy }) => {
+  return (
+    <>
+      <CardContainerWrapper>
+        {dummy.map(({ icon, title, description }, index) => {
+          return (
+            <Card
+              key={'card' + index}
+              iconName={icon}
+              title={title}
+              description={description}
+            ></Card>
+          );
+        })}
+      </CardContainerWrapper>
+    </>
+  );
+};
+
+export default CardContainer;

--- a/client/src/components/presentational/category_tag/CategoryTagDummy.js
+++ b/client/src/components/presentational/category_tag/CategoryTagDummy.js
@@ -1,0 +1,36 @@
+const dummy = {
+  category: [
+    {
+      icon: 'meal',
+      title: '식사',
+      description:
+        '고기, 기타, 배달, 분식, 뷔페, 식재료, 아시아음식, 양식, 일반식당, 일식, 중식, 치킨, 패밀리레스토랑, 패스트푸드, 한식',
+    },
+    {
+      icon: 'cafe',
+      title: '카페/간식',
+      description:
+        '기타, 도넛/아이스크림, 디저트/떡, 베이커리, 샌드위치/핫도그, 자판기, 차/주스/빙수, 커피',
+    },
+    {
+      icon: 'drink',
+      title: '술/유흥',
+      description: '기타, 술집, 유흥시설',
+    },
+    {
+      icon: 'living',
+      title: '생활/마트',
+      description:
+        '가전/가구, 기타, 기프트샵/꽃, 마트, 반려동물, 생활서비스, 육아, 일상용품, 편의점',
+    },
+  ],
+  tag: [
+    { icon: 'tagDefault', title: '가족' },
+    { icon: 'tagDefault', title: '데이트' },
+    { icon: 'tagDefault', title: '선물' },
+    { icon: 'tagDefault', title: '여행' },
+    { icon: 'tagDefault', title: '회사' },
+  ],
+};
+
+export default dummy;

--- a/client/src/components/presentational/category_tag/Navigation.jsx
+++ b/client/src/components/presentational/category_tag/Navigation.jsx
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+
+import color from '@public/color';
+import NavigationMarker from './NavigationMarker';
+
+const NavigationWrapper = styled.div`
+  width: 50%;
+  margin-left: 10px;
+  ul {
+    padding-inline-start: 0px;
+    li {
+      display: inline;
+      list-style-type: none;
+      text-align: center;
+      .nav-title {
+        display: inline-block;
+        width: 50%;
+        pointer-events: none;
+      }
+    }
+  }
+  .normal {
+    color: ${color.fontNormal};
+  }
+  .active {
+    color: ${color.fontBold};
+  }
+  .normal,
+  .active:hover {
+    cursor: pointer;
+  }
+`;
+
+const Navigation = ({ navMenu, setNavMenu }) => {
+  const onNavClick = (e) => {
+    const clicked = e.target.id;
+    if (clicked !== navMenu) {
+      setNavMenu(clicked);
+    }
+  };
+
+  return (
+    <>
+      <NavigationWrapper>
+        <ul>
+          <li
+            id="category"
+            className={navMenu === 'category' ? 'active' : 'normal'}
+            onClick={onNavClick}
+          >
+            <div className="nav-title">카테고리</div>
+          </li>
+          <li
+            id="tag"
+            className={navMenu === 'tag' ? 'active' : 'normal'}
+            onClick={onNavClick}
+          >
+            <div className="nav-title">태그</div>
+          </li>
+          <NavigationMarker selected={navMenu} />
+        </ul>
+      </NavigationWrapper>
+    </>
+  );
+};
+
+export default Navigation;

--- a/client/src/components/presentational/category_tag/NavigationMarker.jsx
+++ b/client/src/components/presentational/category_tag/NavigationMarker.jsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+const NavigationMarkerWrapper = styled.div`
+  hr {
+    height: 0.25rem;
+    width: 50%;
+    margin: 0;
+    background: tomato;
+    border: none;
+    transition: 0.3s ease-in-out;
+    margin-left: ${({ selected }) => (selected === 'tag' ? '50%' : '0%')};
+  }
+`;
+
+const NavigationMarker = ({ selected }) => {
+  return (
+    <>
+      <NavigationMarkerWrapper selected={selected}>
+        <hr />
+      </NavigationMarkerWrapper>
+    </>
+  );
+};
+
+export default NavigationMarker;

--- a/client/src/components/presentational/common/DropDown.jsx
+++ b/client/src/components/presentational/common/DropDown.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Overlay from './Overlay';
+import color from '@public/color';
+
+const DropDownWrapper = styled.div`
+  position: absolute;
+  right: 0px;
+  width: 200px;
+  font-size: 13px;
+  text-align: center;
+  background-color: white;
+  color: ${color.fontLightBold};
+  border: 1px solid ${color.line};
+  box-shadow: ${color.boxShadow};
+  z-index: 12;
+`;
+
+const DropDownOption = styled.div`
+  height: 40px;
+  line-height: 40px;
+  &:not(:last-child) {
+    border-bottom: 1px solid ${color.line};
+  }
+  &:hover {
+    cursor: pointer;
+    color: ${color.dropDownHoverText};
+    background-color: ${color.dropDownHoverBackground};
+  }
+`;
+
+const DropDown = ({ options, setDropDown }) => {
+  const optionOnClick = (e) => {
+    // TODO
+    console.log(e.target.textContent); // TODO: 삭제할 예정(확인용)
+    setDropDown(false);
+  };
+
+  const renderedOptions = options.map((option, index) => {
+    return (
+      <DropDownOption key={'option' + index} onClick={optionOnClick}>
+        {option}
+      </DropDownOption>
+    );
+  });
+
+  return (
+    <>
+      <Overlay setModal={setDropDown} />
+      <DropDownWrapper>{renderedOptions}</DropDownWrapper>
+    </>
+  );
+};
+
+export default DropDown;

--- a/client/src/components/presentational/common/Layout.jsx
+++ b/client/src/components/presentational/common/Layout.jsx
@@ -11,13 +11,14 @@ const ContentWrapper = styled.div`
   top: 61px;
   left: 251px;
   padding: 50px 20px;
-  width: 100%;
+  max-width: 972px;
   height: 100%;
   background-color: ${color.pageBackground};
   transition: 850ms;
 
   @media (max-width: 767px) {
     transform: translate(-231px, 0px);
+    width: 90%;
   }
 `;
 

--- a/client/src/pages/CategoryPage.jsx
+++ b/client/src/pages/CategoryPage.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const CategoryPage = () => {
-  return <div>CategoryPage</div>;
-};
-
-export default CategoryPage;

--- a/client/src/pages/CategoryTagPage.jsx
+++ b/client/src/pages/CategoryTagPage.jsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+import Navigation from '../components/presentational/category_tag/Navigation';
+import CardContainer from '../components/presentational/category_tag/CardContainer';
+import dummy from '../components/presentational/category_tag/CategoryTagDummy';
+
+const CategoryTagPage = () => {
+  const [navMenu, setNavMenu] = useState('category');
+
+  return (
+    <>
+      <Navigation navMenu={navMenu} setNavMenu={setNavMenu} />
+      <CardContainer dummy={navMenu === 'tag' ? dummy.tag : dummy.category} />
+    </>
+  );
+};
+
+export default CategoryTagPage;


### PR DESCRIPTION
## ✅ 작업 내용
- [x] CI: eslintrc.js 수정
missing in props warning 을 없애기 위해 react/prop-types: 0 을 rules에 추가
- [x] style: color.js에 색상 추가 
공통으로 사용될 수 있는 색상들 추가
- [x] style: icon.js 파일 생성 
자주 사용할 수 있는 react icons를 icon.js에서 관리
- [x] feat: 카테고리 태그 페이지 추가 
카테고리, 태그 별도의 두 페이지가 아니라 한 페이지에서 state를 관리하면서 카테고리 또는 태그를 확인할 수 있도록 구현
- [x] feat: 카테고리태그 페이지에서 보여지는 카드 컴포넌트 정의 
카테고리 또는 태그를 담는 카드 컴포넌트를 재사용가능하도록 구현
- [x] feat: 카테고리태그 페이지에서 사용하는 네비게이션 메뉴 구현 
useState를 사용하여 카테고리 혹은 태그를 확인할 수 있도록 네비게이션 메뉴 구현
- [x] feat: 카테고리태그 네이게이션에 대한 애니메이션 구현 
직관적인 UI를 구현하기 위해 별도로 hr을 컴포넌트로 분리한 후 useState 변화에 따라 애니메이션 적용
- [x] style: FE에서 UI확인을 위한 dummy 추가 
카테고리/태그에 대한 dummy 추가(추후 삭제 예정)
- [x] feat: 재사용 가능한 dropdown 구현 
more 아이콘을 누를 경우 나타나는 dropdown(모달) 컴포넌트를 재사용하도록 구현
- [x] style: css 수정
Layout 컴포넌트의 너비 관련 수정

## 📸 스크린샷 (Optional) 
![image](https://user-images.githubusercontent.com/38288479/100684616-07a52b80-33be-11eb-953a-eb7c21c48fdb.png) 
![image](https://user-images.githubusercontent.com/38288479/100684625-0b38b280-33be-11eb-8b0a-62669c4d02be.png)
![image](https://user-images.githubusercontent.com/38288479/100684633-0e33a300-33be-11eb-8d70-50db753c69de.png)


## 🔒 관련이슈 (Optional)
- #20, #22, #24, #25, #26, #27
