### PR TITLE
[BE/FE] 카드/계좌 추가 및 삭제 기능 구현

### DIFF
--- a/client/src/components/containers/PaymentContainer.jsx
+++ b/client/src/components/containers/PaymentContainer.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+
 import { getPayment } from '@service/api';
 import PaymentForm from '@presentational/payment/PaymentForm';
 

--- a/client/src/components/containers/PaymentContainer.jsx
+++ b/client/src/components/containers/PaymentContainer.jsx
@@ -1,22 +1,41 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
-import { getPayment } from '@service/api';
 import PaymentForm from '@presentational/payment/PaymentForm';
+import { paymentLoader } from '@slice';
+import { addPayment } from '@service/api';
 
 const PaymentContainer = () => {
-  const [payments, setPayments] = useState([]);
+  const dispatch = useDispatch();
+  const payments = useSelector((state) => state.payments);
 
   useEffect(async () => {
-    // TODO: 추후 로그인 기능이 완료되면, localStorage에서 정보 가져올 예정
-    const paymentsList = await getPayment({
-      userId: '5fbe261bf9266857e4dd7c3f',
-      accountBookId: '1',
-    });
-
-    setPayments(await paymentsList);
+    dispatch(
+      // TODO: 추후 로그인 기능이 완료되면, localStorage에서 정보 가져올 예정
+      paymentLoader({
+        userId: '5fbe261bf9266857e4dd7c3f',
+        accountBookId: '5fc46c4209dfb476c8bac16d',
+      })
+    );
   }, []);
 
-  return <PaymentForm payments={payments} />;
+  const handleClick = async ({ userId, paymentName }) => {
+    const addResult = await addPayment({
+      userId,
+      paymentName,
+    });
+
+    if (addResult === 'success') {
+      dispatch(
+        paymentLoader({
+          userId,
+          accountBookId: '5fc46c4209dfb476c8bac16d',
+        })
+      );
+    }
+  };
+
+  return <PaymentForm payments={payments} addClick={handleClick} />;
 };
 
 export default PaymentContainer;

--- a/client/src/components/containers/PaymentContainer.jsx
+++ b/client/src/components/containers/PaymentContainer.jsx
@@ -8,7 +8,7 @@ import { addPayment, deletePayment } from '@service/api';
 const PaymentContainer = () => {
   const dispatch = useDispatch();
   const payments = useSelector((state) => state.payments);
-  const changeStatus = async () => {
+  const changeStatus = () => {
     dispatch(
       // TODO: 추후 로그인 기능이 완료되면, localStorage에서 정보 가져올 예정
       paymentLoader({
@@ -18,7 +18,7 @@ const PaymentContainer = () => {
     );
   };
 
-  useEffect(async () => {
+  useEffect(() => {
     changeStatus();
   }, []);
 

--- a/client/src/components/containers/PaymentContainer.jsx
+++ b/client/src/components/containers/PaymentContainer.jsx
@@ -3,13 +3,12 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import PaymentForm from '@presentational/payment/PaymentForm';
 import { paymentLoader } from '@slice';
-import { addPayment } from '@service/api';
+import { addPayment, deletePayment } from '@service/api';
 
 const PaymentContainer = () => {
   const dispatch = useDispatch();
   const payments = useSelector((state) => state.payments);
-
-  useEffect(async () => {
+  const changeStatus = async () => {
     dispatch(
       // TODO: 추후 로그인 기능이 완료되면, localStorage에서 정보 가져올 예정
       paymentLoader({
@@ -17,6 +16,10 @@ const PaymentContainer = () => {
         accountBookId: '5fc46c4209dfb476c8bac16d',
       })
     );
+  };
+
+  useEffect(async () => {
+    changeStatus();
   }, []);
 
   const handleClick = async ({ userId, paymentName }) => {
@@ -26,16 +29,28 @@ const PaymentContainer = () => {
     });
 
     if (addResult === 'success') {
-      dispatch(
-        paymentLoader({
-          userId,
-          accountBookId: '5fc46c4209dfb476c8bac16d',
-        })
-      );
+      changeStatus();
     }
   };
 
-  return <PaymentForm payments={payments} addClick={handleClick} />;
+  const cardDelete = async ({ paymentName }) => {
+    const deleteResult = await deletePayment({
+      userId: '5fbe261bf9266857e4dd7c3f',
+      paymentName,
+    });
+
+    if (deleteResult === 'success') {
+      changeStatus();
+    }
+  };
+
+  return (
+    <PaymentForm
+      payments={payments}
+      addClick={handleClick}
+      cardDelete={cardDelete}
+    />
+  );
 };
 
 export default PaymentContainer;

--- a/client/src/components/presentational/common/DropDown.jsx
+++ b/client/src/components/presentational/common/DropDown.jsx
@@ -30,11 +30,10 @@ const DropDownOption = styled.div`
   }
 `;
 
-const DropDown = ({ options, setDropDown, cardDelete }) => {
+const DropDown = ({ options, setDropDown, cardDelete, titleRef }) => {
   const optionOnClick = (e) => {
     const optionTitle = e.target.textContent;
-    const selectedCardName = e.target.parentNode.parentNode.querySelector('p')
-      .innerText;
+    const selectedCardName = titleRef.current.innerText;
 
     switch (optionTitle) {
       case '카드 삭제':

--- a/client/src/components/presentational/common/DropDown.jsx
+++ b/client/src/components/presentational/common/DropDown.jsx
@@ -30,10 +30,24 @@ const DropDownOption = styled.div`
   }
 `;
 
-const DropDown = ({ options, setDropDown }) => {
+const DropDown = ({ options, setDropDown, cardDelete }) => {
   const optionOnClick = (e) => {
-    // TODO
-    console.log(e.target.textContent); // TODO: 삭제할 예정(확인용)
+    const optionTitle = e.target.textContent;
+    const selectedCardName = e.target.parentNode.parentNode.querySelector('p')
+      .innerText;
+
+    switch (optionTitle) {
+      case '카드 삭제':
+        cardDelete({
+          paymentName: selectedCardName,
+        });
+        break;
+      case '카드 수정':
+        console.log('수정 시작');
+        break;
+      default:
+        break;
+    }
     setDropDown(false);
   };
 

--- a/client/src/components/presentational/payment/AddButton.jsx
+++ b/client/src/components/presentational/payment/AddButton.jsx
@@ -5,7 +5,7 @@ import * as FcIcons from 'react-icons/fc';
 import PaymentModal from './PaymentModal';
 
 const AddPaymentBtn = styled.div`
-  width: 85%;
+  width: 93%;
   display: flex;
   flex-direction: row-reverse;
   cursor: pointer;
@@ -33,7 +33,6 @@ const AddButton = ({ payments, addClick }) => {
           }}
         />
       </AddPaymentBtn>
-
       <PaymentModal
         isOpen={show}
         close={handleClose}

--- a/client/src/components/presentational/payment/AddButton.jsx
+++ b/client/src/components/presentational/payment/AddButton.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import * as FcIcons from 'react-icons/fc';
+
+import PaymentModal from './PaymentModal';
+
+const AddPaymentBtn = styled.div`
+  width: 84%;
+  display: flex;
+  flex-direction: row-reverse;
+  cursor: pointer;
+  border: none;
+  outline: none;
+`;
+
+const AddButton = () => {
+  const AddCard = (cardName) => {
+    console.log(cardName);
+  };
+
+  const [show, setShow] = useState(false);
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
+
+  return (
+    <>
+      <AddPaymentBtn onClick={handleShow}>
+        <FcIcons.FcPlus
+          size={40}
+          style={{
+            filter: `drop-shadow(4px 2px 2px rgba(0, 0, 0, 0.173))`,
+          }}
+        />
+      </AddPaymentBtn>
+
+      <PaymentModal isOpen={show} close={handleClose} AddCard={AddCard} />
+    </>
+  );
+};
+
+export default AddButton;

--- a/client/src/components/presentational/payment/AddButton.jsx
+++ b/client/src/components/presentational/payment/AddButton.jsx
@@ -5,7 +5,7 @@ import * as FcIcons from 'react-icons/fc';
 import PaymentModal from './PaymentModal';
 
 const AddPaymentBtn = styled.div`
-  width: 84%;
+  width: 85%;
   display: flex;
   flex-direction: row-reverse;
   cursor: pointer;
@@ -13,9 +13,9 @@ const AddPaymentBtn = styled.div`
   outline: none;
 `;
 
-const AddButton = () => {
-  const AddCard = (cardName) => {
-    console.log(cardName);
+const AddButton = ({ payments, addClick }) => {
+  const AddCard = async (cardName) => {
+    addClick({ userId: '5fbe261bf9266857e4dd7c3f', paymentName: cardName });
   };
 
   const [show, setShow] = useState(false);
@@ -34,7 +34,12 @@ const AddButton = () => {
         />
       </AddPaymentBtn>
 
-      <PaymentModal isOpen={show} close={handleClose} AddCard={AddCard} />
+      <PaymentModal
+        isOpen={show}
+        close={handleClose}
+        AddCard={AddCard}
+        payments={payments}
+      />
     </>
   );
 };

--- a/client/src/components/presentational/payment/ItemMetadata.jsx
+++ b/client/src/components/presentational/payment/ItemMetadata.jsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import numeral from 'numeral';
+
+import icon from '@public/icon';
+import DropDown from '@presentational/common/DropDown';
+
+const Metadata = styled.div`
+  width: 50%;
+  margin-left: 0.2em;
+`;
+
+const MainWrapper = styled.div`
+  display: flex;
+  position: relative;
+`;
+
+const Title = styled.p`
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: bold;
+`;
+
+const DropDownBtn = styled.div`
+  width: 24px;
+  height: 24px;
+  line-height: 20px;
+  text-align: center;
+  position: absolute;
+  right: 0px;
+  transition: 0.3s;
+
+  svg {
+    fill: #808080;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 0;
+    right: 0;
+    margin: auto;
+    text-align: center;
+  }
+  &:hover {
+    svg {
+      fill: #ffffff;
+    }
+    background: #02aacf;
+    border-radius: 50%;
+  }
+`;
+
+const SubTitle = styled.span`
+  color: #75797e;
+`;
+
+const Cost = styled.p`
+  font-size: 0.8rem;
+`;
+
+const PaymentBtn = styled.button`
+  display: inline-block;
+  padding: 0 16px;
+  margin-top: 10px;
+  min-width: 88px;
+  border: 0;
+  border-radius: 2px;
+  text-align: center;
+  font-size: 14px;
+  line-height: 34px;
+  cursor: pointer;
+  box-shadow: rgba(0, 0, 0, 0.258824) 0 2px 2px 0;
+  background: #fafafa;
+  color: #111;
+  border: none;
+  outline: none;
+
+  &:hover {
+    background: #02aacf;
+    color: white;
+  }
+`;
+
+const ItemMetadata = ({ item, cardDelete }) => {
+  const [dropdown, setDropDown] = useState(false);
+  const dropDownOptions = ['카드 수정', '카드 삭제', '취소'];
+
+  return (
+    <Metadata>
+      <MainWrapper>
+        <Title>{item.payment}</Title>
+        <DropDownBtn onClick={() => setDropDown(!dropdown)}>
+          {icon.more}
+        </DropDownBtn>
+        {dropdown && (
+          <DropDown
+            options={dropDownOptions}
+            setDropDown={setDropDown}
+            cardDelete={cardDelete}
+          />
+        )}
+      </MainWrapper>
+      <Cost>
+        <SubTitle>누적: </SubTitle>
+        {numeral(item.totalCost).format('0,0')}원
+      </Cost>
+      <PaymentBtn>내역 보기</PaymentBtn>
+    </Metadata>
+  );
+};
+
+export default ItemMetadata;

--- a/client/src/components/presentational/payment/ItemMetadata.jsx
+++ b/client/src/components/presentational/payment/ItemMetadata.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import styled from 'styled-components';
 import numeral from 'numeral';
 
@@ -81,13 +81,14 @@ const PaymentBtn = styled.button`
 `;
 
 const ItemMetadata = ({ item, cardDelete }) => {
+  const titleRef = useRef();
   const [dropdown, setDropDown] = useState(false);
   const dropDownOptions = ['카드 수정', '카드 삭제', '취소'];
 
   return (
     <Metadata>
       <MainWrapper>
-        <Title>{item.payment}</Title>
+        <Title ref={titleRef}>{item.payment}</Title>
         <DropDownBtn onClick={() => setDropDown(!dropdown)}>
           {icon.more}
         </DropDownBtn>
@@ -96,6 +97,7 @@ const ItemMetadata = ({ item, cardDelete }) => {
             options={dropDownOptions}
             setDropDown={setDropDown}
             cardDelete={cardDelete}
+            titleRef={titleRef}
           />
         )}
       </MainWrapper>

--- a/client/src/components/presentational/payment/PaymentForm.jsx
+++ b/client/src/components/presentational/payment/PaymentForm.jsx
@@ -1,11 +1,17 @@
 import styled from 'styled-components';
-import * as FcIcons from 'react-icons/fc';
 
 import PaymentItem from '@presentational/payment/PaymentItem';
+import AddButton from '@presentational/payment/AddButton';
 
 const PaymentApp = styled.div`
   display: flex;
   justify-content: center;
+`;
+
+const PaymentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 80rem;
 `;
 
 const Payments = styled.ul`
@@ -13,22 +19,13 @@ const Payments = styled.ul`
   flex-wrap: wrap;
   align-items: center;
   list-style: none;
-  max-width: 80rem;
-`;
-
-const AddPaymentBtn = styled.div`
-  cursor: pointer;
-  border: none;
-  outline: none;
 `;
 
 const PaymentForm = ({ payments }) => {
   return (
-    <>
-      <PaymentApp>
-        {/* <AddPaymentBtn>
-          <FcIcons.FcPlus size={35} />
-        </AddPaymentBtn> */}
+    <PaymentApp>
+      <PaymentWrapper>
+        <AddButton />
 
         {payments !== 'error' && (
           <Payments>
@@ -39,8 +36,8 @@ const PaymentForm = ({ payments }) => {
         )}
 
         {payments === 'error' && <h2>아직 등록된 결제수단이 없습니다!</h2>}
-      </PaymentApp>
-    </>
+      </PaymentWrapper>
+    </PaymentApp>
   );
 };
 

--- a/client/src/components/presentational/payment/PaymentForm.jsx
+++ b/client/src/components/presentational/payment/PaymentForm.jsx
@@ -11,7 +11,7 @@ const PaymentApp = styled.div`
 const PaymentWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  max-width: 80rem;
+  max-width: 100rem;
 `;
 
 const Payments = styled.ul`
@@ -21,7 +21,7 @@ const Payments = styled.ul`
   list-style: none;
 `;
 
-const PaymentForm = ({ payments, addClick }) => {
+const PaymentForm = ({ payments, addClick, cardDelete }) => {
   return (
     <PaymentApp>
       <PaymentWrapper>
@@ -30,12 +30,18 @@ const PaymentForm = ({ payments, addClick }) => {
         {payments !== 'error' && (
           <Payments>
             {payments.map((item, index) => (
-              <PaymentItem key={'payment' + index} item={item} />
+              <PaymentItem
+                key={'payment' + index}
+                item={item}
+                cardDelete={cardDelete}
+              />
             ))}
           </Payments>
         )}
 
-        {payments === 'error' && <h2>아직 등록된 결제수단이 없습니다!</h2>}
+        {(payments === 'error' || payments.length === 0) && (
+          <h2>아직 등록된 결제수단이 없습니다!</h2>
+        )}
       </PaymentWrapper>
     </PaymentApp>
   );

--- a/client/src/components/presentational/payment/PaymentForm.jsx
+++ b/client/src/components/presentational/payment/PaymentForm.jsx
@@ -21,11 +21,11 @@ const Payments = styled.ul`
   list-style: none;
 `;
 
-const PaymentForm = ({ payments }) => {
+const PaymentForm = ({ payments, addClick }) => {
   return (
     <PaymentApp>
       <PaymentWrapper>
-        <AddButton />
+        <AddButton payments={payments} addClick={addClick} />
 
         {payments !== 'error' && (
           <Payments>

--- a/client/src/components/presentational/payment/PaymentItem.jsx
+++ b/client/src/components/presentational/payment/PaymentItem.jsx
@@ -1,16 +1,19 @@
 import styled from 'styled-components';
-import numeral from 'numeral';
+
+import ItemMetadata from '@presentational/payment/ItemMetadata';
 
 const PaymentContainer = styled.li`
-  width: 40%;
-  padding: 0.3em;
-  margin-right: 30px;
+  width: 45%;
+  padding: 0.5em;
+  margin-right: 20px;
 `;
 
 const Payment = styled.div`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  height: 9rem;
+  width: 25rem;
   border: 1px solid lightgray;
   box-shadow: 3px 3px 5px 0px rgba(191, 191, 191, 0.53);
   cursor: pointer;
@@ -21,68 +24,20 @@ const Payment = styled.div`
   }
 `;
 
-const Metadata = styled.div`
-  margin-left: 0.2em;
-`;
-
 const Img = styled.img`
-  width: 50%;
+  width: 40%;
   height: 100%;
   margin-right: 25px;
 `;
 
-const Title = styled.p`
-  margin: 0;
-  font-size: 0.9rem;
-  font-weight: bold;
-`;
-
-const SubTitle = styled.span`
-  color: #75797e;
-`;
-
-const Cost = styled.p`
-  font-size: 0.8rem;
-`;
-
-const PaymentBtn = styled.button`
-  display: inline-block;
-  padding: 0 16px;
-  margin-top: 10px;
-  min-width: 88px;
-  border: 0;
-  border-radius: 2px;
-  text-align: center;
-  font-size: 14px;
-  line-height: 34px;
-  cursor: pointer;
-  box-shadow: rgba(0, 0, 0, 0.258824) 0 2px 2px 0;
-  background: #fafafa;
-  color: #111;
-  border: none;
-  outline: none;
-
-  &:hover {
-    background: #02aacf;
-    color: white;
-  }
-`;
-
-const PaymentItem = ({ item }) => (
+const PaymentItem = ({ item, cardDelete }) => (
   <PaymentContainer>
     <Payment>
       <Img
         src="https://cdn.finda.co.kr/blog/20180724190225/cover-3.jpg"
         alt="card image"
       />
-      <Metadata>
-        <Title>{item.payment}</Title>
-        <Cost>
-          <SubTitle>누적: </SubTitle>
-          {numeral(item.totalCost).format('0,0')}원
-        </Cost>
-        <PaymentBtn>내역 보기</PaymentBtn>
-      </Metadata>
+      <ItemMetadata item={item} cardDelete={cardDelete} />
     </Payment>
   </PaymentContainer>
 );

--- a/client/src/components/presentational/payment/PaymentModal.js
+++ b/client/src/components/presentational/payment/PaymentModal.js
@@ -7,7 +7,7 @@ const Modal = styled.div`
   right: 0;
   bottom: 0;
   left: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.3);
 `;
 
 const ModalWrapper = styled.div`
@@ -70,12 +70,24 @@ const SubTitle = styled.span`
   color: black;
 `;
 
-const PaymentModal = ({ isOpen, close, AddCard }) => {
+const PaymentModal = ({ isOpen, close, AddCard, payments }) => {
   const inputRef = useRef();
 
   const handleAdd = () => {
-    const value = inputRef.current.value;
-    AddCard(value);
+    const newCardName = inputRef.current.value;
+    const existCardName = payments.filter(
+      (item) => item.payment == newCardName
+    );
+
+    if (existCardName.length === 1) {
+      alert(`이미 존재하는 카드입니다 😥 \n카드 명을 다시 입력해주세요! 🤗`);
+      return;
+    } else if (newCardName === '') {
+      alert(`카드 명을 입력해주세요! 🤗`);
+      return;
+    }
+    AddCard(newCardName);
+    close();
   };
 
   const onClick = () => {

--- a/client/src/components/presentational/payment/PaymentModal.js
+++ b/client/src/components/presentational/payment/PaymentModal.js
@@ -1,0 +1,117 @@
+import React, { useRef } from 'react';
+import styled from 'styled-components';
+
+const Modal = styled.div`
+  position: fixed;
+  top: 50px;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.6);
+`;
+
+const ModalWrapper = styled.div`
+  width: 480px;
+  height: 225px;
+  background-color: white;
+  position: relative;
+  box-sizing: border-box;
+  margin: 50px auto;
+  padding: 20px;
+  padding-top: 0;
+  background: #fff;
+  border-radius: 10px;
+`;
+
+const Close = styled.div`
+  float: right;
+  font-size: 30px;
+  margin-bottom: 10px;
+  cursor: pointer;
+`;
+
+const ModalContents = styled.div`
+  margin: 0 auto;
+  width: 100%;
+  position: relative;
+  padding: 0 20px 32px;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const Input = styled.input`
+  margin-top: 10px;
+  border-radius: 2px;
+  width: 100%;
+  height: 40px;
+  border: 1px solid #e5e5e5;
+  padding: 9px 12px;
+  outline: none;
+  box-sizing: border-box;
+`;
+
+const AddBtn = styled.button`
+  height: 40px;
+  font-size: 14px;
+  padding: 13px 30px;
+  cursor: pointer;
+  background-color: #02aacf;
+  color: white;
+  line-height: 1px;
+  margin-top: 20px;
+  margin-bottom: 12px;
+  border-radius: 3px;
+  border-style: none;
+`;
+
+const SubTitle = styled.span`
+  color: black;
+`;
+
+const PaymentModal = ({ isOpen, close, AddCard }) => {
+  const inputRef = useRef();
+
+  const handleAdd = () => {
+    const value = inputRef.current.value;
+    AddCard(value);
+  };
+
+  const onClick = () => {
+    handleAdd();
+  };
+
+  const onKeyPress = (event) => {
+    if (event.key === 'Enter') {
+      handleAdd();
+    }
+  };
+
+  return (
+    <>
+      {isOpen ? (
+        <Modal>
+          <ModalWrapper>
+            <Close onClick={close}>&times;</Close>
+
+            <ModalContents>
+              <SubTitle>💳 카드 명: </SubTitle>
+              <Input
+                ref={inputRef}
+                type="text"
+                placeholder="ex) 카카오 체크카드"
+                onKeyPress={(event) => onKeyPress(event)}
+              />
+              <AddBtn type="submit" onClick={onClick}>
+                카드 등록
+              </AddBtn>
+            </ModalContents>
+          </ModalWrapper>
+        </Modal>
+      ) : null}
+    </>
+  );
+};
+
+export default PaymentModal;

--- a/client/src/components/presentational/payment/PaymentModal.js
+++ b/client/src/components/presentational/payment/PaymentModal.js
@@ -2,8 +2,9 @@ import React, { useRef } from 'react';
 import styled from 'styled-components';
 
 const Modal = styled.div`
+  z-index: 10;
   position: fixed;
-  top: 50px;
+  top: 0;
   right: 0;
   bottom: 0;
   left: 0;

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -37,3 +37,18 @@ export async function addPayment({ userId, paymentName }) {
 
   return data;
 }
+
+export async function deletePayment({ userId, paymentName }) {
+  const url = `${API_URL}/payment/`;
+
+  const { data } = await axios({
+    url: url,
+    method: 'delete',
+    data: {
+      userId,
+      paymentName,
+    },
+  });
+
+  return data;
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -22,3 +22,18 @@ export async function getPayment({ userId, accountBookId }) {
 
   return data;
 }
+
+export async function addPayment({ userId, paymentName }) {
+  const url = `${API_URL}/payment/`;
+
+  const { data } = await axios({
+    url: url,
+    method: 'put',
+    data: {
+      userId,
+      paymentName,
+    },
+  });
+
+  return data;
+}

--- a/client/src/slice.js
+++ b/client/src/slice.js
@@ -1,7 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { fetchTest } from './services/api';
-
+import { fetchTest, getPayment } from '@service/api';
 import { tempTransactionData } from './tempData';
 
 const { actions, reducer } = createSlice({
@@ -9,6 +8,7 @@ const { actions, reducer } = createSlice({
   initialState: {
     test: 1,
     transactions: tempTransactionData,
+    payments: [],
   },
 
   reducers: {
@@ -24,10 +24,16 @@ const { actions, reducer } = createSlice({
         transactions,
       };
     },
+    setPayments(state, { payload: payments }) {
+      return {
+        ...state,
+        payments,
+      };
+    },
   },
 });
 
-export const { setTest } = actions;
+export const { setTest, setPayments } = actions;
 
 export const loader = ({ test }) => {
   console.log('loader', test);
@@ -35,6 +41,17 @@ export const loader = ({ test }) => {
     console.log('asd');
     const testData = await fetchTest({ test });
     dispatch(setTest(testData));
+  };
+};
+
+export const paymentLoader = ({ userId, accountBookId }) => {
+  return async (dispatch) => {
+    const paymentsList = await getPayment({
+      userId,
+      accountBookId,
+    });
+
+    dispatch(setPayments(paymentsList));
   };
 };
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx'],
     alias: {
+      '@slice': path.resolve(__dirname, './src/slice'),
       '@presentational': path.resolve(
         __dirname,
         './src/components/presentational'

--- a/server/src/controller/payment.controller.js
+++ b/server/src/controller/payment.controller.js
@@ -34,6 +34,19 @@ const PaymentController = {
       ctx.body = 'error';
     }
   },
+
+  deletePayment: async (ctx) => {
+    try {
+      const { userId, paymentName } = ctx.request.body;
+
+      await PaymentService.deletePayment(userId, paymentName);
+      ctx.body = 'success';
+
+      return;
+    } catch (err) {
+      ctx.body = 'error';
+    }
+  },
 };
 
 module.exports = PaymentController;

--- a/server/src/controller/payment.controller.js
+++ b/server/src/controller/payment.controller.js
@@ -6,10 +6,10 @@ const PaymentController = {
       const { userId } = ctx.request.params;
       const { accountBookId } = ctx.request.body;
 
-      const paymentsById = await PaymentService.getPayments(userId);
+      const paymentResultsById = await PaymentService.getPayments(userId);
       const paymentsList = await PaymentService.makePaymentsTemplate(
         accountBookId,
-        paymentsById
+        paymentResultsById
       );
 
       if (paymentsList) {

--- a/server/src/controller/payment.controller.js
+++ b/server/src/controller/payment.controller.js
@@ -14,8 +14,22 @@ const PaymentController = {
 
       if (paymentsList) {
         ctx.body = paymentsList;
+
         return;
       }
+    } catch (err) {
+      ctx.body = 'error';
+    }
+  },
+
+  addPayment: async (ctx) => {
+    try {
+      const { userId, paymentName } = ctx.request.body;
+
+      await PaymentService.updatePayment(userId, paymentName);
+      ctx.body = 'success';
+
+      return;
     } catch (err) {
       ctx.body = 'error';
     }

--- a/server/src/controller/payment.controller.js
+++ b/server/src/controller/payment.controller.js
@@ -14,8 +14,6 @@ const PaymentController = {
 
       if (paymentsList) {
         ctx.body = paymentsList;
-
-        return;
       }
     } catch (err) {
       ctx.body = 'error';
@@ -28,8 +26,6 @@ const PaymentController = {
 
       await PaymentService.updatePayment(userId, paymentName);
       ctx.body = 'success';
-
-      return;
     } catch (err) {
       ctx.body = 'error';
     }

--- a/server/src/route/payment.route.js
+++ b/server/src/route/payment.route.js
@@ -5,4 +5,6 @@ const paymentController = require('../controller/payment.controller');
 
 router.post('/:userId', paymentController.getPayments);
 
+router.put('/', paymentController.addPayment);
+
 module.exports = router;

--- a/server/src/route/payment.route.js
+++ b/server/src/route/payment.route.js
@@ -7,4 +7,6 @@ router.post('/:userId', paymentController.getPayments);
 
 router.put('/', paymentController.addPayment);
 
+router.delete('/', paymentController.deletePayment);
+
 module.exports = router;

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -40,6 +40,19 @@ const PaymentService = {
       '요청하신 결제수단의 결제정보를 불러오는데 에러가 발생했습니다.'
     );
   },
+
+  updatePayment: async (userId, paymentName) => {
+    const result = await UserModel.updateOne(
+      { _id: userId },
+      { $push: { paymentMethod: [paymentName] } }
+    );
+
+    if (result.ok === 1) {
+      return 'success';
+    }
+
+    throw new Error('카드 추가에 실패했습니다.');
+  },
 };
 
 module.exports = PaymentService;

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -55,7 +55,7 @@ const PaymentService = {
   },
 
   deletePayment: async (userId, paymentName) => {
-    const result = await UserModel.update(
+    const result = await UserModel.updateOne(
       { _id: userId },
       { $pull: { paymentMethod: paymentName } }
     );

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -3,10 +3,10 @@ const TransactionModel = require('../model/transaction.model');
 
 const PaymentService = {
   getPayments: async (userId) => {
-    const paymentResultById = await UserModel.findOne({ _id: userId });
+    const { paymentMethod } = await UserModel.findOne({ _id: userId });
 
-    if (paymentResultById) {
-      return paymentResultById.paymentMethod;
+    if (paymentMethod) {
+      return paymentMethod;
     }
 
     throw new Error('요청하신 사용자의 결제수단이 존재하지 않습니다.');

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -53,6 +53,19 @@ const PaymentService = {
 
     throw new Error('카드 추가에 실패했습니다.');
   },
+
+  deletePayment: async (userId, paymentName) => {
+    const result = await UserModel.update(
+      { _id: userId },
+      { $pull: { paymentMethod: paymentName } }
+    );
+
+    if (result.ok === 1) {
+      return 'success';
+    }
+
+    throw new Error('카드 삭제에 실패했습니다.');
+  },
 };
 
 module.exports = PaymentService;


### PR DESCRIPTION
## ✅ 작업 내용
### BE
- [X] [BE] 카드/계좌 API 서비스 로직 리팩토링
  - Transaction db와의 연결을 최소화 시키고, filter를 적용했습니다.
    - 기봉님 리뷰를 반영했습니다! 부족한 부분은 다시 말씀해주세요 :)
- [X] [BE] 카드 정보 추가하는 API 개발
    - 추가할 카드 번호와 userId를 보내면 -> 사용자의 카드 정보에 새로운 카드를 추가하는 API를 개발했습니다.
- [X] [BE] 카드 정보 삭제하는 API 개발
    - 삭제할 카드 번호와 userId를 보내면 -> 요청한 카드를 삭제하는 API를 개발했습니다.

### FE
- [X] [FE] useSelector, useDispatch를 이용한 payment 상태 관리
  - 각 컴포넌트에서 payment의 정보를 확인할 수 있도록 useSelector, useDispatch를 이용하여 상태관리를 진행했습니다.
- [X] [FE] 카드 추가 버튼 구현 & modal 구현
  - 카드 추가 버튼을 클릭하면 카드를 등록할 수 있는 모달이 나타나게 됩니다.
- [X] [FE] 카드 정보 추가 및 예외처리 구현
  - `기존에 있는 카드 명을 입력` 할 경우 => 이미 존재하는 카드 명이라고 alert! 
  -` 카드 명을 입력하지 않고 카드 추가를 요청할 시` 예외처리를 진행했습니다.
- [X] [FE] 컴포넌트 분리 & 반응형 디자인 수정
  - PaymentItem 컴포넌트가 커져 Item 안에 들어있는 Metadata 정보를 따로 컴포넌트로 분리했습니다.
  - 반응형 적용을 위해 디자인 적으로 수정을 진행했습니다.
- [X] [FE] 카드 정보 삭제 구현 
  - 카드 정보를 삭제하면, DB에서 정보 삭제 및 화면 리렌더링을 진행했습니다.
  - 함수를 통해 삭제할 카드 명을 받아들이고, dispatch와 loader를 이용하여 상태관리를 진행했습니다.

## 🔨 변경 사항 (구현 사항)
- [X] 카드 추가 기능
- [X] 카드 삭제 기능

## 📸 스크린샷

- ![image](https://user-images.githubusercontent.com/13073517/100727711-f71aa280-3409-11eb-9fde-f3a5ce75c2d2.png)
- ![image](https://user-images.githubusercontent.com/13073517/100727749-01d53780-340a-11eb-8bb9-0a4f2cc6d0d6.png)
- ![image](https://user-images.githubusercontent.com/13073517/100727792-0bf73600-340a-11eb-9264-0df012f1e396.png)
- ![image](https://user-images.githubusercontent.com/13073517/100727826-15809e00-340a-11eb-8243-647f67e852a6.png)
- ![image](https://user-images.githubusercontent.com/13073517/100727846-1dd8d900-340a-11eb-8553-05b7c06ace43.png)
 

## 🔒 관련이슈
- FE: #19 #23 #29
- BE: #37 #39
