### PR TITLE
[BE/FE] 카드 별 수입/지출 내역 시각화

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1100,6 +1100,49 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@devexpress/dx-chart-core": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@devexpress/dx-chart-core/-/dx-chart-core-2.7.3.tgz",
+      "integrity": "sha512-lR2ES0D5hLXJoruef2u5dW0OEo4tMwfIiaFXrFDZrnQ3oAycnzXJ6ULWsB3ody7vpeXYQ/2EekAF/A5+aRS7mw==",
+      "requires": {
+        "d3-array": "^2.4.0",
+        "d3-scale": "^3.2.0",
+        "d3-shape": "^1.3.7"
+      }
+    },
+    "@devexpress/dx-core": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@devexpress/dx-core/-/dx-core-2.7.3.tgz",
+      "integrity": "sha512-FDky6X3+SuOylyMrtCjOyoku3LRN4VE2rIoxQ90G/tBkPLDjzR2dOYO1iR3pBpeP4Ib9Ifl0GaU9/YJeVGjnhQ=="
+    },
+    "@devexpress/dx-react-chart": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@devexpress/dx-react-chart/-/dx-react-chart-2.7.3.tgz",
+      "integrity": "sha512-6fJFefDN0IyQsv6Fd/f7BaadZNahrNWOVhc1IRdzkuSivbptyzGtIB08j8+RbXrGeoascjaOAGDF8z908f0/SQ==",
+      "requires": {
+        "@devexpress/dx-chart-core": "2.7.3",
+        "d3-scale": "^3.2.0",
+        "d3-shape": "^1.3.7"
+      }
+    },
+    "@devexpress/dx-react-chart-material-ui": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@devexpress/dx-react-chart-material-ui/-/dx-react-chart-material-ui-2.7.3.tgz",
+      "integrity": "sha512-7Yc2I8u/n9Y7IlPx19Wmh7oeThSxp1yS2frE3n0z/Ebow5/yXB3TsFmcCfMfDG95GSgW1tCrmWULNvIf6LVrNQ==",
+      "requires": {
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@devexpress/dx-react-core": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@devexpress/dx-react-core/-/dx-react-core-2.7.3.tgz",
+      "integrity": "sha512-me8+ZhGxBjyTJq5STmnH7oAwsrhVrlb/vYaykB06BAerR04s9qwW4D7tzwCMFeeZN9I5DwBlV/pVU4PPT80TjA==",
+      "requires": {
+        "@devexpress/dx-core": "2.7.3",
+        "prop-types": "^15.7.2"
+      }
+    },
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1100,6 +1100,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -1150,6 +1155,101 @@
             "type-fest": "^0.8.1"
           }
         }
+      }
+    },
+    "@material-ui/core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.2.tgz",
+      "integrity": "sha512-/D1+AQQeYX/WhT/FUk78UCRj8ch/RCglsQLYujYTIqPSJlwZHKcvHidNeVhODXeApojeXjkl0tWdk5C9ofwOkQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.11.2",
+        "@material-ui/system": "^4.11.2",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.11.2",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0",
+        "react-transition-group": "^4.4.0"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+        },
+        "dom-helpers": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+          "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+          "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        }
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.2.tgz",
+      "integrity": "sha512-xbItf8zkfD3FuGoD9f2vlcyPf9jTEtj9YTJoNNV+NMWaSAHXgrW6geqRoo/IwBuMjqpwqsZhct13e2nUyU9Ljw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.0.3",
+        "jss-plugin-camel-case": "^10.0.3",
+        "jss-plugin-default-unit": "^10.0.3",
+        "jss-plugin-global": "^10.0.3",
+        "jss-plugin-nested": "^10.0.3",
+        "jss-plugin-props-sort": "^10.0.3",
+        "jss-plugin-rule-value-function": "^10.0.3",
+        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.2.tgz",
+      "integrity": "sha512-BELFJEel5E+5DMiZb6XXT3peWRn6UixRvBtKwSxqntmD0+zwbbfCij6jtGwwdJhN1qX/aXrKu10zX31GBaeR7A==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "csstype": "^2.5.2",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+    },
+    "@material-ui/utils": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+      "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -1220,6 +1320,35 @@
       "version": "14.14.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
       "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg=="
+    },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
+    "@types/react": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
+      "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+        }
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -2403,6 +2532,11 @@
         }
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -2783,11 +2917,25 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
+    "css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
+      }
+    },
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
       "dev": true
+    },
+    "csstype": {
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+      "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -4759,6 +4907,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4824,6 +4977,14 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "indefinite-observable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-2.0.1.tgz",
+      "integrity": "sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==",
+      "requires": {
+        "symbol-observable": "1.2.0"
+      }
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -5031,6 +5192,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+    },
     "is-negative-zero": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
@@ -5197,6 +5363,92 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jss": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.0.tgz",
+      "integrity": "sha512-B6151NvG+thUg3murLNHRPLxTLwQ13ep4SH5brj4d8qKtogOx/jupnpfkPGSHPqvcwKJaCLctpj2lEk+5yGwMw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "indefinite-observable": "^2.0.1",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+        }
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.0.tgz",
+      "integrity": "sha512-GSjPL0adGAkuoqeYiXTgO7PlIrmjv5v8lA6TTBdfxbNYpxADOdGKJgIEkffhlyuIZHlPuuiFYTwUreLUmSn7rg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.5.0"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.0.tgz",
+      "integrity": "sha512-rsbTtZGCMrbcb9beiDd+TwL991NGmsAgVYH0hATrYJtue9e+LH/Gn4yFD1ENwE+3JzF3A+rPnM2JuD9L/SIIWw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.5.0.tgz",
+      "integrity": "sha512-FZd9+JE/3D7HMefEG54fEC0XiQ9rhGtDHAT/ols24y8sKQ1D5KIw6OyXEmIdKFmACgxZV2ARQ5pAUypxkk2IFQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.5.0.tgz",
+      "integrity": "sha512-ejPlCLNlEGgx8jmMiDk/zarsCZk+DV0YqXfddpgzbO9Toamo0HweCFuwJ3ZO40UFOfqKwfpKMVH/3HUXgxkTMg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.0.tgz",
+      "integrity": "sha512-kTLRvrOetFKz5vM88FAhLNeJIxfjhCepnvq65G7xsAQ/Wgy7HwO1BS/2wE5mx8iLaAWC6Rj5h16mhMk9sKdZxg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.0.tgz",
+      "integrity": "sha512-jXINGr8BSsB13JVuK274oEtk0LoooYSJqTBCGeBu2cG/VJ3+4FPs1gwLgsq24xTgKshtZ+WEQMVL34OprLidRA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.0.tgz",
+      "integrity": "sha512-rux3gmfwDdOKCLDx0IQjTwTm03IfBa+Rm/hs747cOw5Q7O3RaTUIMPKjtVfc31Xr/XI9Abz2XEupk1/oMQ7zRA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.8",
+        "jss": "10.5.0"
       }
     },
     "jsx-ast-utils": {
@@ -6243,6 +6495,11 @@
       "requires": {
         "find-up": "^3.0.0"
       }
+    },
+    "popper.js": {
+      "version": "1.16.1-lts",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
     },
     "portfinder": {
       "version": "1.0.28",

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,10 @@
     "webpack-dev-server": "^3.7.2"
   },
   "dependencies": {
+    "@devexpress/dx-core": "^2.7.3",
+    "@devexpress/dx-react-chart": "^2.7.3",
+    "@devexpress/dx-react-chart-material-ui": "^2.7.3",
+    "@devexpress/dx-react-core": "^2.7.3",
     "@material-ui/core": "^4.11.2",
     "@reduxjs/toolkit": "^1.4.0",
     "axios": "^0.21.0",

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
     "webpack-dev-server": "^3.7.2"
   },
   "dependencies": {
+    "@material-ui/core": "^4.11.2",
     "@reduxjs/toolkit": "^1.4.0",
     "axios": "^0.21.0",
     "clean-webpack-plugin": "^3.0.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import CategoryTagPage from './pages/CategoryTagPage';
 import DashboardPage from './pages/DashboardPage';
 import NotFoundPage from './pages/NotFoundPage';
 import PaymentMethodPage from './pages/PaymentMethodPage';
+import PaymentDetailPage from './pages/PaymentDetailPage';
 import SettingPage from './pages/SettingPage';
 import TransactionPage from './pages/TransactionPage';
 import Layout from './components/presentational/common/Layout';
@@ -34,6 +35,7 @@ const App = () => {
           <Route exact path="/calendar" component={CalendarPage} />
           <Route path="/category" component={CategoryTagPage} />
           <Route path="/dashboard" component={DashboardPage} />
+          <Route path="/payment-method/:id" component={PaymentDetailPage} />
           <Route path="/payment-method" component={PaymentMethodPage} />
           <Route path="/setting" component={SettingPage} />
           <Route path="/transaction" component={TransactionPage} />

--- a/client/src/components/containers/PaymentContainer.jsx
+++ b/client/src/components/containers/PaymentContainer.jsx
@@ -13,7 +13,7 @@ const PaymentContainer = () => {
       // TODO: 추후 로그인 기능이 완료되면, localStorage에서 정보 가져올 예정
       loadPayment({
         userId: '5fbe261bf9266857e4dd7c3f',
-        accountBookId: '5fc46c4209dfb476c8bac16d',
+        accountBookId: '5fc713abd120a78e5c18216d',
       })
     );
   }, []);

--- a/client/src/components/containers/PaymentContainer.jsx
+++ b/client/src/components/containers/PaymentContainer.jsx
@@ -9,17 +9,11 @@ const PaymentContainer = () => {
   const payments = useSelector((state) => state.payments);
 
   useEffect(() => {
-    dispatch(
-      // TODO: 추후 로그인 기능이 완료되면, localStorage에서 정보 가져올 예정
-      loadPayment({
-        userId: '5fbe261bf9266857e4dd7c3f',
-        accountBookId: '5fc713abd120a78e5c18216d',
-      })
-    );
+    dispatch(loadPayment());
   }, []);
 
-  const handleClick = ({ userId, paymentName }) => {
-    dispatch(addPayment({ userId, paymentName }));
+  const handleClick = ({ paymentName }) => {
+    dispatch(addPayment({ paymentName }));
   };
 
   const cardDelete = ({ paymentName }) => {

--- a/client/src/components/containers/PaymentContainer.jsx
+++ b/client/src/components/containers/PaymentContainer.jsx
@@ -2,7 +2,12 @@ import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import PaymentForm from '@presentational/payment/PaymentForm';
-import { loadPayment, addPayment, removePayment, changePayment } from '@slice';
+import {
+  loadPayment,
+  addPayment,
+  removePayment,
+  changePayment,
+} from '@paymentSlice';
 
 const PaymentContainer = () => {
   const dispatch = useDispatch();

--- a/client/src/components/containers/PaymentDetailContainer.jsx
+++ b/client/src/components/containers/PaymentDetailContainer.jsx
@@ -7,14 +7,14 @@ import { loadDetailPayment } from '@paymentSlice';
 const PaymentDetailContainer = (cardName) => {
   const dispatch = useDispatch();
   const transactions = useSelector((state) => state.transactions);
+  const title = transactions[transactions.length - 1].title;
 
   useEffect(() => {
     dispatch(loadDetailPayment(cardName.id));
   }, []);
 
   const showAll = () => {
-    console.log('전체 내역');
-    //dispatch(addPayment());
+    dispatch(loadDetailPayment(cardName.id));
   };
 
   const showIncome = () => {
@@ -29,6 +29,7 @@ const PaymentDetailContainer = (cardName) => {
 
   return (
     <DetailForm
+      title={title}
       transactions={transactions}
       showAll={showAll}
       showIncome={showIncome}

--- a/client/src/components/containers/PaymentDetailContainer.jsx
+++ b/client/src/components/containers/PaymentDetailContainer.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import DetailForm from '@presentational/payment/detail/DetailForm';
+import { loadDetailPayment } from '@paymentSlice';
+
+const PaymentDetailContainer = (cardName) => {
+  const dispatch = useDispatch();
+  const transactions = useSelector((state) => state.transactions);
+
+  useEffect(() => {
+    dispatch(loadDetailPayment(cardName.id));
+  }, []);
+
+  const showAll = () => {
+    console.log('전체 내역');
+    //dispatch(addPayment());
+  };
+
+  const showIncome = () => {
+    console.log('수입 내역');
+    //dispatch(addPayment());
+  };
+
+  const showExpenditure = () => {
+    console.log('지출 내역');
+    //dispatch(addPayment());
+  };
+
+  return (
+    <DetailForm
+      transactions={transactions}
+      showAll={showAll}
+      showIncome={showIncome}
+      showExpenditure={showExpenditure}
+    />
+  );
+};
+
+export default PaymentDetailContainer;

--- a/client/src/components/presentational/payment/AddButton.jsx
+++ b/client/src/components/presentational/payment/AddButton.jsx
@@ -15,7 +15,7 @@ const AddPaymentBtn = styled.div`
 
 const AddButton = ({ payments, addClick }) => {
   const AddCard = async (cardName) => {
-    addClick({ userId: '5fbe261bf9266857e4dd7c3f', paymentName: cardName });
+    addClick({ paymentName: cardName });
   };
 
   const [show, setShow] = useState(false);

--- a/client/src/components/presentational/payment/ItemMetadata.jsx
+++ b/client/src/components/presentational/payment/ItemMetadata.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import numeral from 'numeral';
 
@@ -106,7 +107,9 @@ const ItemMetadata = ({ item, cardDelete, cardUpdate }) => {
         <SubTitle>누적: </SubTitle>
         {numeral(item.totalCost).format('0,0')}원
       </Cost>
-      <PaymentBtn>내역 보기</PaymentBtn>
+      <Link to={`/payment-method/${item.payment}`}>
+        <PaymentBtn>내역 보기</PaymentBtn>
+      </Link>
     </Metadata>
   );
 };

--- a/client/src/components/presentational/payment/detail/DetailButton.jsx
+++ b/client/src/components/presentational/payment/detail/DetailButton.jsx
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  margin: {
+    margin: theme.spacing(1),
+  },
+}));
+
+const PaymentApp = styled.div`
+  display: flex;
+  width: 50vw;
+  justify-content: center;
+  margin-bottom: 15px;
+`;
+
+const DetailButton = ({ showAll, showIncome, showExpenditure }) => {
+  const classes = useStyles();
+
+  return (
+    <PaymentApp>
+      <Button
+        variant="outlined"
+        color="default"
+        className={classes.margin}
+        onClick={() => {
+          showAll();
+        }}
+      >
+        ALL
+      </Button>
+
+      <Button
+        variant="outlined"
+        color="primary"
+        className={classes.margin}
+        onClick={() => {
+          showIncome();
+        }}
+      >
+        수입
+      </Button>
+
+      <Button
+        variant="outlined"
+        color="secondary"
+        className={classes.margin}
+        onClick={() => {
+          showExpenditure();
+        }}
+      >
+        지출
+      </Button>
+    </PaymentApp>
+  );
+};
+
+export default DetailButton;

--- a/client/src/components/presentational/payment/detail/DetailForm.jsx
+++ b/client/src/components/presentational/payment/detail/DetailForm.jsx
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import {
+  Chart,
+  BarSeries,
+  Title,
+  ArgumentAxis,
+  ValueAxis,
+} from '@devexpress/dx-react-chart-material-ui';
+
+import { Animation } from '@devexpress/dx-react-chart';
+
+const PaymentApp = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 55vw;
+  margin-bottom: 15px;
+`;
+
+const useStyles = makeStyles((theme) => ({
+  margin: {
+    margin: theme.spacing(1),
+  },
+}));
+
+const DetailForm = ({
+  title,
+  transactions,
+  showAll,
+  showIncome,
+  showExpenditure,
+}) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <PaymentApp>
+        <Button
+          variant="outlined"
+          color="default"
+          className={classes.margin}
+          onClick={() => {
+            showAll();
+          }}
+        >
+          ALL
+        </Button>
+
+        <Button
+          variant="outlined"
+          color="primary"
+          className={classes.margin}
+          onClick={() => {
+            showIncome();
+          }}
+        >
+          수입
+        </Button>
+
+        <Button
+          variant="outlined"
+          color="secondary"
+          className={classes.margin}
+          onClick={() => {
+            showExpenditure();
+          }}
+        >
+          지출
+        </Button>
+      </PaymentApp>
+
+      <Paper>
+        <Chart data={transactions}>
+          <ArgumentAxis />
+          <ValueAxis max={20} />
+
+          <BarSeries
+            valueField="cost"
+            argumentField="category"
+            color="#f50057"
+          />
+          <Title text={title} />
+          <Animation />
+        </Chart>
+      </Paper>
+    </>
+  );
+};
+
+export default DetailForm;

--- a/client/src/components/presentational/payment/detail/DetailForm.jsx
+++ b/client/src/components/presentational/payment/detail/DetailForm.jsx
@@ -1,6 +1,4 @@
 import styled from 'styled-components';
-import Button from '@material-ui/core/Button';
-import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import {
   Chart,
@@ -9,21 +7,24 @@ import {
   ArgumentAxis,
   ValueAxis,
 } from '@devexpress/dx-react-chart-material-ui';
-
 import { Animation } from '@devexpress/dx-react-chart';
 
-const PaymentApp = styled.div`
+import DetailButton from './DetailButton';
+
+const PaymentDetail = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: center;
-  width: 55vw;
-  margin-bottom: 15px;
+  width: 50vw;
 `;
 
-const useStyles = makeStyles((theme) => ({
-  margin: {
-    margin: theme.spacing(1),
-  },
-}));
+const NoContents = styled.div`
+  display: flex;
+  width: 50vw;
+  justify-content: center;
+  font-size: 1rem;
+  margin-top: 20px;
+`;
 
 const DetailForm = ({
   title,
@@ -32,60 +33,33 @@ const DetailForm = ({
   showIncome,
   showExpenditure,
 }) => {
-  const classes = useStyles();
-
   return (
-    <>
-      <PaymentApp>
-        <Button
-          variant="outlined"
-          color="default"
-          className={classes.margin}
-          onClick={() => {
-            showAll();
-          }}
-        >
-          ALL
-        </Button>
+    <PaymentDetail>
+      <DetailButton
+        showAll={showAll}
+        showIncome={showIncome}
+        showExpenditure={showExpenditure}
+      />
 
-        <Button
-          variant="outlined"
-          color="primary"
-          className={classes.margin}
-          onClick={() => {
-            showIncome();
-          }}
-        >
-          수입
-        </Button>
-
-        <Button
-          variant="outlined"
-          color="secondary"
-          className={classes.margin}
-          onClick={() => {
-            showExpenditure();
-          }}
-        >
-          지출
-        </Button>
-      </PaymentApp>
-
-      <Paper>
-        <Chart data={transactions}>
-          <ArgumentAxis />
-          <ValueAxis max={20} />
-
-          <BarSeries
-            valueField="cost"
-            argumentField="category"
-            color="#f50057"
-          />
-          <Title text={title} />
-          <Animation />
-        </Chart>
-      </Paper>
-    </>
+      {transactions.length === 1 ? (
+        <NoContents>요청하신 카드의 사용 내역이 존재하지 않습니다.</NoContents>
+      ) : (
+        <Paper>
+          <Chart data={transactions}>
+            <ArgumentAxis />
+            <ValueAxis max={20} />
+            <BarSeries
+              valueField="cost"
+              argumentField="_id"
+              color="#f50057"
+              barWidth="0.5"
+            />
+            <Title text={title} />
+            <Animation />
+          </Chart>
+        </Paper>
+      )}
+    </PaymentDetail>
   );
 };
 

--- a/client/src/pages/PaymentDetailPage.jsx
+++ b/client/src/pages/PaymentDetailPage.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import PaymentDetailContainer from '../components/containers/PaymentDetailContainer';
+
+const PaymentApp = styled.div`
+  display: flex;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: bold;
+  width: 55vw;
+  margin-bottom: 20px;
+`;
+
+const PaymentDetailPage = ({ match }) => {
+  return (
+    <>
+      <PaymentApp>💳 {match.params.id} 💳 카드 사용 내역</PaymentApp>
+
+      <PaymentDetailContainer id={match.params.id} />
+    </>
+  );
+};
+
+export default PaymentDetailPage;

--- a/client/src/pages/PaymentDetailPage.jsx
+++ b/client/src/pages/PaymentDetailPage.jsx
@@ -8,7 +8,7 @@ const PaymentApp = styled.div`
   justify-content: center;
   font-size: 18px;
   font-weight: bold;
-  width: 55vw;
+  width: 50vw;
   margin-bottom: 20px;
 `;
 

--- a/client/src/paymentSlice.js
+++ b/client/src/paymentSlice.js
@@ -1,0 +1,84 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import {
+  getPayment,
+  patchPayment,
+  deletePayment,
+  updatePayment,
+  getAllTransaction,
+} from '@service/paymentAPI';
+
+const { actions, reducer } = createSlice({
+  name: 'app',
+  initialState: {
+    payments: [],
+    transactions: [],
+  },
+  accessToken: '',
+
+  reducers: {
+    setPayments(state, { payload: payments }) {
+      return {
+        ...state,
+        payments,
+      };
+    },
+    setTransaction(state, { payload: transactions }) {
+      return {
+        ...state,
+        transactions,
+      };
+    },
+  },
+});
+
+export const { setPayments, setTransaction } = actions;
+
+export const loadPayment = () => {
+  return async (dispatch) => {
+    const paymentsList = await getPayment();
+
+    dispatch(setPayments(paymentsList));
+  };
+};
+
+export const loadDetailPayment = (cardName) => {
+  return async (dispatch) => {
+    const paymentsList = await getAllTransaction(cardName);
+
+    dispatch(setTransaction(paymentsList));
+  };
+};
+
+export const addPayment = ({ paymentName }) => {
+  return async (dispatch) => {
+    await patchPayment({
+      paymentName,
+    });
+
+    dispatch(loadPayment());
+  };
+};
+
+export const removePayment = ({ paymentName }) => {
+  return async (dispatch) => {
+    await deletePayment({
+      paymentName,
+    });
+
+    dispatch(loadPayment());
+  };
+};
+
+export const changePayment = ({ selectedCardName, newCardName }) => {
+  return async (dispatch) => {
+    await updatePayment({
+      selectedCardName,
+      newCardName,
+    });
+
+    dispatch(loadPayment());
+  };
+};
+
+export default reducer;

--- a/client/src/paymentSlice.js
+++ b/client/src/paymentSlice.js
@@ -23,7 +23,7 @@ const { actions, reducer } = createSlice({
         payments,
       };
     },
-    setTransaction(state, { payload: transactions }) {
+    setTransactions(state, { payload: transactions }) {
       return {
         ...state,
         transactions,
@@ -32,7 +32,7 @@ const { actions, reducer } = createSlice({
   },
 });
 
-export const { setPayments, setTransaction } = actions;
+export const { setPayments, setTransactions } = actions;
 
 export const loadPayment = () => {
   return async (dispatch) => {
@@ -46,7 +46,7 @@ export const loadDetailPayment = (cardName) => {
   return async (dispatch) => {
     const paymentsList = await getAllTransaction(cardName);
 
-    dispatch(setTransaction(paymentsList));
+    dispatch(setTransactions(paymentsList));
   };
 };
 

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,11 +1,5 @@
 import axios from 'axios';
-import {
-  axiosAPI,
-  getOptions,
-  patchOptions,
-  deleteOptions,
-} from '../../util/axios';
-import { getToken } from '../../util/token';
+import { axiosAPI } from '../../util/axios';
 
 const API_URL = process.env.API_URL;
 
@@ -13,40 +7,6 @@ export async function fetchTest({ test }) {
   console.log(test);
   const url = `${API_URL}/user`;
   const { data } = await axios(url);
-  return data;
-}
-
-export async function getPayment() {
-  const url = `${API_URL}/payment/`;
-  const { data } = await axios(getOptions(url));
-
-  return data;
-}
-
-export async function patchPayment({ paymentName }) {
-  const url = `${API_URL}/payment/`;
-  const body = { paymentName };
-
-  const { data } = await axios(patchOptions(url, body));
-
-  return data;
-}
-
-export async function deletePayment({ paymentName }) {
-  const url = `${API_URL}/payment/`;
-  const body = { paymentName };
-
-  const { data } = await axios(deleteOptions(url, body));
-
-  return data;
-}
-
-export async function updatePayment({ selectedCardName, newCardName }) {
-  const url = `${API_URL}/payment/update`;
-  const body = { selectedCardName, newCardName };
-
-  const { data } = await axios(patchOptions(url, body));
-
   return data;
 }
 

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import axiosAPI from '../../util/axios';
+import { getToken } from '../../util/token';
 
 const API_URL = process.env.API_URL;
 
@@ -10,14 +11,16 @@ export async function fetchTest({ test }) {
   return data;
 }
 
-export async function getPayment({ userId, accountBookId }) {
-  const url = `${API_URL}/payment/${userId}`;
+export async function getPayment({ accountBookId }) {
+  const url = `${API_URL}/payment/${accountBookId}`;
 
   const { data } = await axios({
     url: url,
-    method: 'post',
-    data: {
-      accountBookId: accountBookId,
+    method: 'get',
+    headers: {
+      'Content-Type': 'application/jso; charset=UTF-8',
+      Authorization: `Bearer ${getToken()}`,
+      userid: '5fbe261bf9266857e4dd7c3f',
     },
   });
 
@@ -98,6 +101,5 @@ export async function postLoginNaver(code) {
 
 export async function getTags({ accountBookId }) {
   const { data } = await axiosAPI(`/accountBook/${accountBookId}`, 'GET');
-
   return data.tags;
 }

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,5 +1,10 @@
 import axios from 'axios';
-import axiosAPI from '../../util/axios';
+import {
+  axiosAPI,
+  getOptions,
+  patchOptions,
+  deleteOptions,
+} from '../../util/axios';
 import { getToken } from '../../util/token';
 
 const API_URL = process.env.API_URL;
@@ -11,64 +16,36 @@ export async function fetchTest({ test }) {
   return data;
 }
 
-export async function getPayment({ accountBookId }) {
-  const url = `${API_URL}/payment/${accountBookId}`;
-
-  const { data } = await axios({
-    url: url,
-    method: 'get',
-    headers: {
-      'Content-Type': 'application/jso; charset=UTF-8',
-      Authorization: `Bearer ${getToken()}`,
-      userid: '5fbe261bf9266857e4dd7c3f',
-    },
-  });
-
-  return data;
-}
-
-export async function patchPayment({ userId, paymentName }) {
+export async function getPayment() {
   const url = `${API_URL}/payment/`;
-
-  const { data } = await axios({
-    url: url,
-    method: 'patch',
-    data: {
-      userId,
-      paymentName,
-    },
-  });
+  const { data } = await axios(getOptions(url));
 
   return data;
 }
 
-export async function deletePayment({ userId, paymentName }) {
+export async function patchPayment({ paymentName }) {
   const url = `${API_URL}/payment/`;
+  const body = { paymentName };
 
-  const { data } = await axios({
-    url: url,
-    method: 'delete',
-    data: {
-      userId,
-      paymentName,
-    },
-  });
+  const { data } = await axios(patchOptions(url, body));
 
   return data;
 }
 
-export async function updatePayment({ userId, selectedCardName, newCardName }) {
+export async function deletePayment({ paymentName }) {
+  const url = `${API_URL}/payment/`;
+  const body = { paymentName };
+
+  const { data } = await axios(deleteOptions(url, body));
+
+  return data;
+}
+
+export async function updatePayment({ selectedCardName, newCardName }) {
   const url = `${API_URL}/payment/update`;
+  const body = { selectedCardName, newCardName };
 
-  const { data } = await axios({
-    url: url,
-    method: 'patch',
-    data: {
-      userId,
-      selectedCardName,
-      newCardName,
-    },
-  });
+  const { data } = await axios(patchOptions(url, body));
 
   return data;
 }

--- a/client/src/services/paymentAPI.js
+++ b/client/src/services/paymentAPI.js
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { getOptions, patchOptions, deleteOptions } from '../../util/axios';
+
+const API_URL = process.env.API_URL;
+
+export async function getPayment() {
+  const url = `${API_URL}/payment/`;
+  const { data } = await axios(getOptions(url));
+
+  return data;
+}
+
+export async function getAllTransaction(cardName) {
+  const url = `${API_URL}/payment/${cardName}`;
+  const { data } = await axios(getOptions(url));
+
+  return data;
+}
+
+export async function patchPayment({ paymentName }) {
+  const url = `${API_URL}/payment/`;
+  const body = { paymentName };
+
+  const { data } = await axios(patchOptions(url, body));
+
+  return data;
+}
+
+export async function deletePayment({ paymentName }) {
+  const url = `${API_URL}/payment/`;
+  const body = { paymentName };
+
+  const { data } = await axios(deleteOptions(url, body));
+
+  return data;
+}
+
+export async function updatePayment({ selectedCardName, newCardName }) {
+  const url = `${API_URL}/payment/update`;
+  const body = { selectedCardName, newCardName };
+
+  const { data } = await axios(patchOptions(url, body));
+
+  return data;
+}

--- a/client/src/slice.js
+++ b/client/src/slice.js
@@ -82,63 +82,42 @@ export function login({ code, state }) {
   };
 }
 
-export const loadPayment = ({ userId, accountBookId }) => {
+export const loadPayment = () => {
   return async (dispatch) => {
-    const paymentsList = await getPayment({
-      userId,
-      accountBookId,
-    });
+    const paymentsList = await getPayment();
 
     dispatch(setPayments(paymentsList));
   };
 };
 
-export const addPayment = ({ userId, paymentName }) => {
+export const addPayment = ({ paymentName }) => {
   return async (dispatch) => {
     await patchPayment({
-      userId,
       paymentName,
     });
 
-    dispatch(
-      loadPayment({
-        userId,
-        accountBookId: '5fc46c4209dfb476c8bac16d',
-      })
-    );
+    dispatch(loadPayment());
   };
 };
 
 export const removePayment = ({ paymentName }) => {
   return async (dispatch) => {
     await deletePayment({
-      userId: '5fbe261bf9266857e4dd7c3f',
       paymentName,
     });
 
-    dispatch(
-      loadPayment({
-        userId: '5fbe261bf9266857e4dd7c3f',
-        accountBookId: '5fc46c4209dfb476c8bac16d',
-      })
-    );
+    dispatch(loadPayment());
   };
 };
 
 export const changePayment = ({ selectedCardName, newCardName }) => {
   return async (dispatch) => {
     await updatePayment({
-      userId: '5fbe261bf9266857e4dd7c3f',
       selectedCardName,
       newCardName,
     });
 
-    dispatch(
-      loadPayment({
-        userId: '5fbe261bf9266857e4dd7c3f',
-        accountBookId: '5fc713abd120a78e5c18216d',
-      })
-    );
+    dispatch(loadPayment());
   };
 };
 

--- a/client/src/slice.js
+++ b/client/src/slice.js
@@ -4,12 +4,15 @@ import {
   fetchTest,
   postLoginGithub,
   postLoginNaver,
+  getTags,
+} from '@service/api';
+
+import {
   getPayment,
   patchPayment,
   deletePayment,
   updatePayment,
-  getTags,
-} from '@service/api';
+} from '@service/paymentAPI';
 
 import { tempTransactionData } from './tempData';
 

--- a/client/src/slice.js
+++ b/client/src/slice.js
@@ -8,7 +8,7 @@ import {
   patchPayment,
   deletePayment,
   updatePayment,
-  getTags
+  getTags,
 } from '@service/api';
 
 import { tempTransactionData } from './tempData';
@@ -82,7 +82,6 @@ export function login({ code, state }) {
   };
 }
 
-
 export const loadPayment = ({ userId, accountBookId }) => {
   return async (dispatch) => {
     const paymentsList = await getPayment({
@@ -137,7 +136,7 @@ export const changePayment = ({ selectedCardName, newCardName }) => {
     dispatch(
       loadPayment({
         userId: '5fbe261bf9266857e4dd7c3f',
-        accountBookId: '5fc46c4209dfb476c8bac16d',
+        accountBookId: '5fc713abd120a78e5c18216d',
       })
     );
   };

--- a/client/util/axios.js
+++ b/client/util/axios.js
@@ -1,22 +1,62 @@
 import axios from 'axios';
 import { getToken } from './token';
 
-const axiosAPI = (url, method, body) => {
+const accountBookId = '5fc713abd120a78e5c18216d'; // TODO: Local Storage에서 get해 올 예정
+
+export const axiosAPI = (url, method, body) => {
   return axios({
     url,
     method,
     baseURL: process.env.API_URL,
-    mode: 'cors',
+    // mode: 'cors',
     credentials: 'include',
     withCredentials: true,
     headers: {
       'Content-Type': 'application/json; charset=UTF-8',
       Authorization: `Bearer ${getToken()}`,
-      userid: '5fbe261bf9266857e4dd7c3f', // TODO: 추후 삭제
-      //userid: '5fc67adeecfd3cb85cc7fb4d' // TODO: 추후 삭제
+      userid: '5fc67adeecfd3cb85cc7fb4d', // TODO: 추후 삭제
     },
     data: body,
   });
 };
 
-export default axiosAPI;
+export const getOptions = (url) => {
+  return {
+    url,
+    method: 'get',
+    headers: {
+      'Content-Type': 'application/json; charset=UTF-8',
+      Authorization: `Bearer ${getToken()}`,
+      userid: '5fc67adeecfd3cb85cc7fb4d', // TODO: 추후 삭제
+      accountBookId,
+    },
+  };
+};
+
+export const patchOptions = (url, data) => {
+  return {
+    url,
+    method: 'patch',
+    headers: {
+      'Content-Type': 'application/json; charset=UTF-8',
+      Authorization: `Bearer ${getToken()}`,
+      userid: '5fc67adeecfd3cb85cc7fb4d', // TODO: 추후 삭제
+      accountBookId,
+    },
+    data,
+  };
+};
+
+export const deleteOptions = (url, data) => {
+  return {
+    url,
+    method: 'delete',
+    headers: {
+      'Content-Type': 'application/json; charset=UTF-8',
+      Authorization: `Bearer ${getToken()}`,
+      userid: '5fc67adeecfd3cb85cc7fb4d', // TODO: 추후 삭제
+      accountBookId,
+    },
+    data,
+  };
+};

--- a/client/util/axios.js
+++ b/client/util/axios.js
@@ -6,12 +6,14 @@ const axiosAPI = (url, method, body) => {
     url,
     method,
     baseURL: process.env.API_URL,
+    mode: 'cors',
     credentials: 'include',
     withCredentials: true,
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json; charset=UTF-8',
       Authorization: `Bearer ${getToken()}`,
-      userid: '5fc67adeecfd3cb85cc7fb4d', // TODO: 추후 삭제
+      userid: '5fbe261bf9266857e4dd7c3f', // TODO: 추후 삭제
+      //userid: '5fc67adeecfd3cb85cc7fb4d' // TODO: 추후 삭제
     },
     data: body,
   });

--- a/client/util/axios.js
+++ b/client/util/axios.js
@@ -8,11 +8,10 @@ export const axiosAPI = (url, method, body) => {
     url,
     method,
     baseURL: process.env.API_URL,
-    // mode: 'cors',
     credentials: 'include',
     withCredentials: true,
     headers: {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       Authorization: `Bearer ${getToken()}`,
       userid: '5fc67adeecfd3cb85cc7fb4d', // TODO: 추후 삭제
     },

--- a/client/util/token.js
+++ b/client/util/token.js
@@ -1,6 +1,8 @@
-export const setToken = (token) => {
-  localStorage.setItem('token', token);
-};
-export const getToken = () => localStorage.getItem('token');
+// TODO: accessToken 네이밍이 바뀌면 다시 수정 필요
 
-export const removeToken = () => localStorage.removeItem('token');
+export const setToken = (token) => {
+  localStorage.setItem('accessToken', token);
+};
+export const getToken = () => localStorage.getItem('accessToken');
+
+export const removeToken = () => localStorage.removeItem('accessToken');

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx'],
     alias: {
+      '@paymentSlice': path.resolve(__dirname, './src/paymentSlice'),
       '@slice': path.resolve(__dirname, './src/slice'),
       '@presentational': path.resolve(
         __dirname,

--- a/server/src/controller/payment.controller.js
+++ b/server/src/controller/payment.controller.js
@@ -3,10 +3,13 @@ const PaymentService = require('../service/payment.service');
 const PaymentController = {
   getPayments: async (ctx) => {
     try {
-      const { userId } = ctx.request.params;
-      const { accountBookId } = ctx.request.body;
-
-      const paymentResultsById = await PaymentService.getPayments(userId);
+      const { userid } = ctx.request.header;
+      const { accountBookId } = ctx.request.params;
+      //const { accountBookId } = ctx.request.body;
+      console.log(accountBookId);
+      const paymentResultsById = await PaymentService.getPayments(
+        accountBookId
+      );
       const paymentsList = await PaymentService.makePaymentsTemplate(
         accountBookId,
         paymentResultsById

--- a/server/src/controller/payment.controller.js
+++ b/server/src/controller/payment.controller.js
@@ -3,13 +3,12 @@ const PaymentService = require('../service/payment.service');
 const PaymentController = {
   getPayments: async (ctx) => {
     try {
-      const { userid } = ctx.request.header;
-      const { accountBookId } = ctx.request.params;
-      //const { accountBookId } = ctx.request.body;
-      console.log(accountBookId);
+      const { accountbookid: accountBookId } = ctx.request.header;
+
       const paymentResultsById = await PaymentService.getPayments(
         accountBookId
       );
+
       const paymentsList = await PaymentService.makePaymentsTemplate(
         accountBookId,
         paymentResultsById
@@ -25,9 +24,13 @@ const PaymentController = {
 
   addPayment: async (ctx) => {
     try {
-      const { userId, paymentName } = ctx.request.body;
+      const { accountbookid: accountBookId } = ctx.request.header;
+      const { paymentName } = ctx.request.body;
 
-      const paymentList = await PaymentService.addPayment(userId, paymentName);
+      const paymentList = await PaymentService.addPayment(
+        accountBookId,
+        paymentName
+      );
 
       ctx.body = paymentList;
     } catch (err) {
@@ -37,10 +40,11 @@ const PaymentController = {
 
   deletePayment: async (ctx) => {
     try {
-      const { userId, paymentName } = ctx.request.body;
+      const { accountbookid: accountBookId } = ctx.request.header;
+      const { paymentName } = ctx.request.body;
 
       const paymentList = await PaymentService.deletePayment(
-        userId,
+        accountBookId,
         paymentName
       );
 
@@ -52,10 +56,11 @@ const PaymentController = {
 
   updatePayment: async (ctx) => {
     try {
-      const { userId, selectedCardName, newCardName } = ctx.request.body;
+      const { accountbookid: accountBookId } = ctx.request.header;
+      const { selectedCardName, newCardName } = ctx.request.body;
 
       const paymentList = await PaymentService.updatePayment(
-        userId,
+        accountBookId,
         selectedCardName,
         newCardName
       );

--- a/server/src/controller/payment.controller.js
+++ b/server/src/controller/payment.controller.js
@@ -22,6 +22,24 @@ const PaymentController = {
     }
   },
 
+  getAllTransaction: async (ctx) => {
+    try {
+      const { cardName } = ctx.request.params;
+      const { accountbookid: accountBookId } = ctx.request.header;
+
+      const paymentsList = await PaymentService.getAllTransaction(
+        cardName,
+        accountBookId
+      );
+
+      if (paymentsList) {
+        ctx.body = paymentsList;
+      }
+    } catch (err) {
+      ctx.throw(err.code, err);
+    }
+  },
+
   addPayment: async (ctx) => {
     try {
       const { accountbookid: accountBookId } = ctx.request.header;

--- a/server/src/route/payment.route.js
+++ b/server/src/route/payment.route.js
@@ -3,11 +3,9 @@ const router = new Router();
 
 const paymentController = require('../controller/payment.controller');
 
-router.get('/:accountBookId', paymentController.getPayments);
-
+router.get('/', paymentController.getPayments);
 router.patch('/', paymentController.addPayment);
 router.patch('/update', paymentController.updatePayment);
-
 router.delete('/', paymentController.deletePayment);
 
 module.exports = router;

--- a/server/src/route/payment.route.js
+++ b/server/src/route/payment.route.js
@@ -3,7 +3,7 @@ const router = new Router();
 
 const paymentController = require('../controller/payment.controller');
 
-router.post('/:userId', paymentController.getPayments);
+router.get('/:accountBookId', paymentController.getPayments);
 
 router.patch('/', paymentController.addPayment);
 router.patch('/update', paymentController.updatePayment);

--- a/server/src/route/payment.route.js
+++ b/server/src/route/payment.route.js
@@ -4,8 +4,11 @@ const router = new Router();
 const paymentController = require('../controller/payment.controller');
 
 router.get('/', paymentController.getPayments);
+router.get('/:cardName', paymentController.getAllTransaction);
+
 router.patch('/', paymentController.addPayment);
 router.patch('/update', paymentController.updatePayment);
+
 router.delete('/', paymentController.deletePayment);
 
 module.exports = router;

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -20,13 +20,22 @@ const PaymentService = {
   },
 
   getAllTransaction: async (cardName, accountBookId) => {
-    const allTransactionList = await TransactionModel.find({
+    let transactionList = await TransactionModel.find({
       accountBookId,
       paymentMethod: cardName,
     });
 
-    if (allTransactionList) {
-      return allTransactionList;
+    if (transactionList) {
+      let totalCost = 0;
+
+      for (let transaction of transactionList) {
+        totalCost += transaction.cost;
+      }
+
+      transactionList.push({ title: `💸 수입/지출 내역 : ${totalCost}원` });
+      console.log(transactionList);
+
+      return transactionList;
     }
 
     throw newError({

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -1,10 +1,16 @@
 const UserModel = require('../model/user.model');
 const TransactionModel = require('../model/transaction.model');
+const AccountBookModel = require('../model/accountBook.model');
+
 const newError = require('../util/error');
 
 const PaymentService = {
-  getPayments: async (userId) => {
-    const { paymentMethod } = await UserModel.findOne({ _id: userId });
+  getPayments: async (accountBookId) => {
+    const { paymentMethod } = await AccountBookModel.findOne({
+      _id: accountBookId,
+    });
+
+    // const { paymentMethod } = await UserModel.findOne({ _id: userId });
 
     if (paymentMethod) {
       return paymentMethod;
@@ -22,6 +28,8 @@ const PaymentService = {
       accountBookId: accountBookId,
       paymentMethod: { $in: [...paymentResultsById] },
     });
+
+    console.log(transactionList);
 
     for (let [index, payment] of paymentList.entries()) {
       let totalCost = 0;

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -20,10 +20,17 @@ const PaymentService = {
   },
 
   getAllTransaction: async (cardName, accountBookId) => {
-    let transactionList = await TransactionModel.find({
-      accountBookId,
-      paymentMethod: cardName,
-    });
+    let transactionList = await TransactionModel.aggregate([
+      {
+        $match: { paymentMethod: cardName },
+      },
+      {
+        $group: {
+          _id: '$category',
+          cost: { $sum: '$cost' },
+        },
+      },
+    ]);
 
     if (transactionList) {
       let totalCost = 0;
@@ -33,7 +40,6 @@ const PaymentService = {
       }
 
       transactionList.push({ title: `💸 수입/지출 내역 : ${totalCost}원` });
-      console.log(transactionList);
 
       return transactionList;
     }

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -1,4 +1,3 @@
-const UserModel = require('../model/user.model');
 const TransactionModel = require('../model/transaction.model');
 const AccountBookModel = require('../model/accountBook.model');
 
@@ -10,15 +9,13 @@ const PaymentService = {
       _id: accountBookId,
     });
 
-    // const { paymentMethod } = await UserModel.findOne({ _id: userId });
-
     if (paymentMethod) {
       return paymentMethod;
     }
 
     throw newError({
       status: 'BAD REQUEST',
-      msg: '요청하신 사용자의 결제수단이 존재하지 않습니다.',
+      msg: '요청하신 가계부에 결제수단이 존재하지 않습니다.',
     });
   },
 
@@ -28,8 +25,6 @@ const PaymentService = {
       accountBookId: accountBookId,
       paymentMethod: { $in: [...paymentResultsById] },
     });
-
-    console.log(transactionList);
 
     for (let [index, payment] of paymentList.entries()) {
       let totalCost = 0;
@@ -54,9 +49,9 @@ const PaymentService = {
     });
   },
 
-  addPayment: async (userId, paymentName) => {
-    const result = await UserModel.updateOne(
-      { _id: userId },
+  addPayment: async (accountBookId, paymentName) => {
+    const result = await AccountBookModel.updateOne(
+      { _id: accountBookId },
       { $push: { paymentMethod: [paymentName] } }
     );
 
@@ -70,9 +65,9 @@ const PaymentService = {
     });
   },
 
-  deletePayment: async (userId, paymentName) => {
-    const result = await UserModel.updateOne(
-      { _id: userId },
+  deletePayment: async (accountBookId, paymentName) => {
+    const result = await AccountBookModel.updateOne(
+      { _id: accountBookId },
       { $pull: { paymentMethod: paymentName } }
     );
 
@@ -86,15 +81,15 @@ const PaymentService = {
     });
   },
 
-  updatePayment: async (userId, selectedCardName, newCardName) => {
-    const { paymentMethod } = await UserModel.findOne({
-      _id: userId,
+  updatePayment: async (accountBookId, selectedCardName, newCardName) => {
+    const { paymentMethod } = await AccountBookModel.findOne({
+      _id: accountBookId,
     });
 
     const cardIndex = paymentMethod.indexOf(selectedCardName);
 
-    const result = await UserModel.updateOne(
-      { _id: userId },
+    const result = await AccountBookModel.updateOne(
+      { _id: accountBookId },
       { $set: { [`paymentMethod.${cardIndex}`]: newCardName } }
     );
 

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -19,6 +19,22 @@ const PaymentService = {
     });
   },
 
+  getAllTransaction: async (cardName, accountBookId) => {
+    const allTransactionList = await TransactionModel.find({
+      accountBookId,
+      paymentMethod: cardName,
+    });
+
+    if (allTransactionList) {
+      return allTransactionList;
+    }
+
+    throw newError({
+      status: 'BAD REQUEST',
+      msg: '요청하신 거래내역이 존재하지 않습니다.',
+    });
+  },
+
   makePaymentsTemplate: async (accountBookId, paymentResultsById) => {
     const paymentList = [...paymentResultsById];
     const transactionList = await TransactionModel.find({


### PR DESCRIPTION
## ✅ 작업 내용
**[BE]**
- [X] 카드/계좌 backend 연동을 위한 frontend 리팩토링
  - 수동으로 받았던 userId, accountBookId 파라미터 정보를 삭제했습니다.
  - userId, accountBookId 정보를 body가 아닌, header에서 가져오도록 수정했습니다.
  - userModel -> AccountBookModel로 연결을 변경했습니다.
- [X] 카테고리별 cost 비용 계산을 위한 group(group by) 적용
<br />

**[FE]**
- [X]  axios get, delete, patch option 추가
  - get, delete, patch 관련 중복되는 옵션 부분을 axios.js에 추가했습니다
- [X] 특정 결제수단을 선택하면 보여지는 payment 상세 페이지 구현
- [X] 수입/지출 정보 그래프 구현 & 데이터 없을 경우 예외처리 진행 
  - 현재는 수입/지출이 보여지는 그래프를 구현했습니다.
  - **추후, 수입 별, 지출 별 시각화 진행할 예정입니다.**
<br/>

**모듈 설치**
- @material-ui/core 설치
  -  컴포넌트 디자인을 위해 @material-ui/core를 설치했습니다.
- @DevExpress 설치
  - 차트 시각화를 위해 @DevExpress를 설치했습니다.

## 📸 스크린샷 (Optional)
- ![image](https://user-images.githubusercontent.com/13073517/101106384-48e24900-3613-11eb-8900-564fcb5a2424.png)
- ![image](https://user-images.githubusercontent.com/13073517/101106406-526bb100-3613-11eb-878b-d4385934650e.png)


## 🔒 관련이슈 (Optional)
- close #56 #57 #58 #21
