### PR TITLE
[FE/BE] 카드/계좌 상세 페이지 - 필터링 기능 추가

### DIFF
--- a/client/src/components/containers/PaymentDetailContainer.jsx
+++ b/client/src/components/containers/PaymentDetailContainer.jsx
@@ -7,27 +7,32 @@ import { loadDetailPayment } from '@slice';
 const PaymentDetailContainer = (cardName) => {
   const dispatch = useDispatch();
   const [color, setColor] = useState('#ffc221');
+
+  const date = new Date();
+  const [year, setYear] = useState(date.getFullYear());
+  const [month, setMonth] = useState(date.getMonth() + 1);
+
   const transactions = useSelector((state) => state.paymentsDetail);
 
   const title = transactions[transactions.length - 1].title;
 
   useEffect(() => {
-    dispatch(loadDetailPayment(cardName.id, 'all'));
+    dispatch(loadDetailPayment(cardName.id, 'all', year, month));
   }, []);
 
   const showAll = () => {
     setColor('#ffc221');
-    dispatch(loadDetailPayment(cardName.id, 'all'));
+    dispatch(loadDetailPayment(cardName.id, 'all', year, month));
   };
 
   const showIncome = () => {
     setColor('#3682e8');
-    dispatch(loadDetailPayment(cardName.id, 'income'));
+    dispatch(loadDetailPayment(cardName.id, 'income', year, month));
   };
 
   const showExpenditure = () => {
     setColor('#ff616a');
-    dispatch(loadDetailPayment(cardName.id, 'expenditure'));
+    dispatch(loadDetailPayment(cardName.id, 'expenditure', year, month));
   };
 
   return (
@@ -38,6 +43,8 @@ const PaymentDetailContainer = (cardName) => {
       showAll={showAll}
       showIncome={showIncome}
       showExpenditure={showExpenditure}
+      setYear={setYear}
+      setMonth={setMonth}
     />
   );
 };

--- a/client/src/components/presentational/payment/detail/DetailDropdown.jsx
+++ b/client/src/components/presentational/payment/detail/DetailDropdown.jsx
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+import { v4 as uuid } from 'uuid';
+
+import { makeStyles } from '@material-ui/core/styles';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+
+import setDateList from './SetDateList';
+
+const DateList = setDateList();
+
+const PaymentApp = styled.div`
+  display: flex;
+  width: 50vw;
+  justify-content: center;
+  margin-bottom: 15px;
+`;
+
+const DetailDropdown = ({ setYear, setMonth }) => {
+  const useStyles = makeStyles((theme) => ({
+    formControl: {
+      margin: theme.spacing(1),
+      minWidth: 140,
+    },
+    selectEmpty: {
+      marginTop: theme.spacing(2),
+    },
+  }));
+
+  const classes = useStyles();
+  const [date, setDate] = React.useState('');
+
+  const handleChange = (event) => {
+    setDate(event.target.value);
+    setYear(event.target.value.year);
+    setMonth(event.target.value.month);
+  };
+
+  return (
+    <PaymentApp>
+      <FormControl className={classes.formControl}>
+        <InputLabel id="demo-simple-select-autowidth-label">
+          카드 사용 년/월
+        </InputLabel>
+        <Select
+          labelId="demo-simple-select-autowidth-label"
+          id="demo-simple-select-autowidth"
+          value={date}
+          onChange={handleChange}
+          autoWidth
+        >
+          {DateList.map((item) => {
+            return (
+              <MenuItem key={uuid()} value={item}>
+                {item.title}
+              </MenuItem>
+            );
+          })}
+        </Select>
+      </FormControl>
+    </PaymentApp>
+  );
+};
+
+export default DetailDropdown;

--- a/client/src/components/presentational/payment/detail/DetailForm.jsx
+++ b/client/src/components/presentational/payment/detail/DetailForm.jsx
@@ -10,6 +10,7 @@ import {
 import { Animation } from '@devexpress/dx-react-chart';
 
 import DetailButton from './DetailButton';
+import DetailDropdown from './DetailDropdown';
 
 const PaymentDetail = styled.div`
   display: flex;
@@ -38,9 +39,12 @@ const DetailForm = ({
   showAll,
   showIncome,
   showExpenditure,
+  setYear,
+  setMonth,
 }) => {
   return (
     <PaymentDetail>
+      <DetailDropdown setYear={setYear} setMonth={setMonth} />
       <DetailButton
         showAll={showAll}
         showIncome={showIncome}

--- a/client/src/components/presentational/payment/detail/SetDateList.js
+++ b/client/src/components/presentational/payment/detail/SetDateList.js
@@ -1,0 +1,33 @@
+const date = new Date();
+
+const SetDateList = () => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+
+  let beforeYear = null;
+  let beforeMonth = null;
+
+  let DateList = [];
+
+  for (let i = 0; i < 6; i++) {
+    const diff = month - i;
+
+    if (diff <= 0) {
+      beforeMonth = 12 + diff;
+      beforeYear = year - 1;
+    } else {
+      beforeMonth = diff;
+      beforeYear = year;
+    }
+
+    DateList.push({
+      title: `${beforeYear}년 ${beforeMonth}월`,
+      year: beforeYear,
+      month: beforeMonth,
+    });
+  }
+
+  return DateList;
+};
+
+export default SetDateList;

--- a/client/src/services/paymentAPI.js
+++ b/client/src/services/paymentAPI.js
@@ -15,8 +15,8 @@ export async function getPayments() {
   return data;
 }
 
-export async function getPaymentsDetail(cardName, type) {
-  const url = `${API_URL}/payment/${cardName}/${type}`;
+export async function getPaymentsDetail(cardName, type, year, month) {
+  const url = `${API_URL}/payment/${cardName}/${type}/${year}/${month}`;
   const { data } = await axios(getOptions(url));
 
   return data;

--- a/client/src/slice.js
+++ b/client/src/slice.js
@@ -149,9 +149,9 @@ export const loadPayment = () => {
   };
 };
 
-export const loadDetailPayment = (cardName, type) => {
+export const loadDetailPayment = (cardName, type, year, month) => {
   return async (dispatch) => {
-    const paymentsList = await getPaymentsDetail(cardName, type);
+    const paymentsList = await getPaymentsDetail(cardName, type, year, month);
 
     dispatch(setPaymentsDetail(paymentsList));
   };
@@ -280,5 +280,5 @@ export const updateDate = ({ date }) => {
     dispatch(setDate({ selectedDate: date }));
   };
 };
-      
+
 export default reducer;

--- a/server/src/controller/payment.controller.js
+++ b/server/src/controller/payment.controller.js
@@ -24,13 +24,15 @@ const PaymentController = {
 
   getTransactions: async (ctx) => {
     try {
-      const { cardName, type } = ctx.request.params;
+      const { cardName, type, year, month } = ctx.request.params;
       const { accountbookid: accountBookId } = ctx.request.header;
 
       const paymentsList = await PaymentService.getTransactions(
         cardName,
         accountBookId,
-        type
+        type,
+        year,
+        month
       );
 
       if (paymentsList) {

--- a/server/src/route/payment.route.js
+++ b/server/src/route/payment.route.js
@@ -4,7 +4,7 @@ const router = new Router();
 const paymentController = require('../controller/payment.controller');
 
 router.get('/', paymentController.getPayments);
-router.get('/:cardName/:type', paymentController.getTransactions);
+router.get('/:cardName/:type/:year/:month', paymentController.getTransactions);
 
 router.post('/', paymentController.addPayment);
 router.patch('/', paymentController.updatePayment);

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -21,16 +21,28 @@ const PaymentService = {
     });
   },
 
-  getTransactions: async (cardName, accountBookId, type) => {
+  getTransactions: async (cardName, accountBookId, type, year, month) => {
     let transactionList = null;
 
     switch (type) {
       case 'all':
         transactionList = await TransactionModel.aggregate([
           {
+            $project: {
+              paymentMethod: 1,
+              accountBookId: 1,
+              category: 1,
+              cost: 1,
+              month: { $month: '$date' },
+              year: { $year: '$date' },
+            },
+          },
+          {
             $match: {
               paymentMethod: cardName,
               accountBookId: ObjectId(accountBookId),
+              month: Number(month),
+              year: Number(year),
             },
           },
           {

--- a/server/src/service/payment.service.js
+++ b/server/src/service/payment.service.js
@@ -56,9 +56,22 @@ const PaymentService = {
       case 'income':
         transactionList = await TransactionModel.aggregate([
           {
+            $project: {
+              paymentMethod: 1,
+              accountBookId: 1,
+              category: 1,
+              cost: 1,
+              type: 1,
+              month: { $month: '$date' },
+              year: { $year: '$date' },
+            },
+          },
+          {
             $match: {
               paymentMethod: cardName,
               accountBookId: ObjectId(accountBookId),
+              month: Number(month),
+              year: Number(year),
               type: '수입',
             },
           },
@@ -73,9 +86,22 @@ const PaymentService = {
       case 'expenditure':
         transactionList = await TransactionModel.aggregate([
           {
+            $project: {
+              paymentMethod: 1,
+              accountBookId: 1,
+              category: 1,
+              cost: 1,
+              type: 1,
+              month: { $month: '$date' },
+              year: { $year: '$date' },
+            },
+          },
+          {
             $match: {
               paymentMethod: cardName,
               accountBookId: ObjectId(accountBookId),
+              month: Number(month),
+              year: Number(year),
               type: '지출',
             },
           },


### PR DESCRIPTION
## ✅ 작업 내용
- [X] [BE] 카드/계좌 거래 내역 조회 시, 년도와 월 검토하는 query 구현
  - 기존에는 `가계부 ID`와 `카드 명`만 확인했다면 `년도`와 `월`도 추가로 확인하여 거래내역을 필터링하도록 구현했습니다.
- [X] [FE] 최근 6개월 년도와 월을 구해 date list 리턴해주는 함수 구현
  - dropdown에 쓰기위한 데이터 list를 만들기 위해 함수를 구현했습니다.
- [X] [FE] 최근 6개월 년도, 월을 선택할 수 있는 dropdown 구현
  - 이번 달 ~ 최근 6개월 내림차순

## 📸 스크린샷
![image](https://user-images.githubusercontent.com/13073517/101421031-c4efd000-3936-11eb-98b0-7b3a1162e4b9.png)
![image](https://user-images.githubusercontent.com/13073517/101420987-b0abd300-3936-11eb-8905-fbd7c5b27beb.png)
![image](https://user-images.githubusercontent.com/13073517/101420592-e3090080-3935-11eb-97f6-2d2e5f5f2cd5.png)


## 🔒 관련이슈
- close #70 #71
