### PR TITLE
[FE] refactor: 자잘한 디자인 수정

### DIFF
--- a/client/src/components/presentational/LoginForm.jsx
+++ b/client/src/components/presentational/LoginForm.jsx
@@ -89,6 +89,7 @@ const StyledImage = styled.img`
 `;
 
 const Title = styled.span`
+  margin-top: 2rem;
   margin-bottom: 3rem;
   font-weight: bolder;
   font-size: 3vw;
@@ -143,7 +144,6 @@ const LoginForm = () => {
               </SubText>
             </Box>
             <Box color="black">
-              <GitHubSvg />
               <Title>
                 지금 당신의 지갑에서 무슨 일이 일어나고 있는지 알아보세요.
               </Title>

--- a/client/src/components/presentational/common/UserMenuDropDown.jsx
+++ b/client/src/components/presentational/common/UserMenuDropDown.jsx
@@ -17,6 +17,7 @@ const UserMenuDropDownWrapper = styled.div`
   color: ${color.fontLightBold};
   border: 1px solid ${color.line};
   box-shadow: ${color.boxShadow};
+  cursor: pointer;
   z-index: 12;
   .dropdown-option {
     height: 40px;


### PR DESCRIPTION
로그인 화면에서 github svg를 삭제했습니다.

정보수정, 로그아웃 드랍다운 마우스오버 시, 포인터 모양으로 변경

## ✅ 작업 내용
- [X] 로그인 화면에서 github svg를 삭제했습니다.
- [X] 정보수정, 로그아웃 드랍다운 마우스오버 시, 포인터 모양으로 변경

## 📸 스크린샷 (Optional)

## 🔒 관련이슈 (Optional)
